### PR TITLE
[BUGFIX] Do not require meta package `typo3/minimal`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "require": {
         "php": "~7.0",
         "phpstan/phpstan": "^0.10",
-        "typo3/cms-core": "^8.7.0 || ~9.0",
-        "typo3/cms-extbase": "^8.7.0 || ~9.0"
+        "typo3/cms-core": "^8.7 || ^9.5",
+        "typo3/cms-extbase": "^8.7 || ^9.5"
     },
     "suggest": {
         "typo3/testing-framework": "Testing framework is used in the bootstrap (src/PhpStanTypo3Bootstrap.php). In most cases you need this package but you may also use your custom bootstrap (e.g. if you use nimut/testing-framework)"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,11 @@
     "require": {
         "php": "~7.0",
         "phpstan/phpstan": "^0.10",
-        "typo3/minimal": "^8.7.0 || ~9.0"
+        "typo3/cms-core": "^8.7.0 || ~9.0",
+        "typo3/cms-extbase": "^8.7.0 || ~9.0"
+    },
+    "suggest": {
+        "typo3/testing-framework": "Testing framework is used in the bootstrap (src/PhpStanTypo3Bootstrap.php). In most cases you need this package but you may also use your custom bootstrap (e.g. if you use nimut/testing-framework)"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Do not require the meta package `typo3/minimal` but require
the packages that are really required by the package itself.

Do also add a suggestion to install `typo3/testing-framework`
as it is required by the bootstrap.

Fixes #3