### PR TITLE
Feature/update phpstan to v0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "require": {
         "php": "~7.1",
-        "phpstan/phpstan": "^0.10",
+        "phpstan/phpstan": "^0.11",
         "typo3/cms-core": "^8.7 || ^9.5",
         "typo3/cms-extbase": "^8.7 || ^9.5"
     },

--- a/src/Reflection/RepositoryMethodsClassReflectionExtension.php
+++ b/src/Reflection/RepositoryMethodsClassReflectionExtension.php
@@ -24,7 +24,7 @@ class RepositoryMethodsClassReflectionExtension implements MethodsClassReflectio
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
         if (
-            !$classReflection->getNativeReflection()->hasMethod($methodName)
+            !$classReflection->getNativeReflection()->hasMethod($methodName)->yes()
             && $classReflection->isSubclassOf(\TYPO3\CMS\Extbase\Persistence\Repository::class)
         ) {
             return 0 === strpos($methodName, 'findBy') || 0 === strpos($methodName, 'findOneBy');

--- a/src/Type/ObjectStorageDynamicReturnTypeExtension.php
+++ b/src/Type/ObjectStorageDynamicReturnTypeExtension.php
@@ -41,7 +41,7 @@ class ObjectStorageDynamicReturnTypeExtension implements DynamicMethodReturnType
             $propertyName = lcfirst(substr($methodCall->var->name, 3));
 
             $class = $scope->getClassReflection();
-            if ($class->hasProperty($propertyName)) {
+            if ($class->hasProperty($propertyName)->yes()) {
                 preg_match(
                     '/@var\\ \\\\TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\ObjectStorage<(.*)>/',
                     $class->getNativeReflection()->getProperty($propertyName)->getDocComment(),


### PR DESCRIPTION
Hi,

I've updated phpstan/phpstan from v0.10 to v0.11. I looked through the [breaking changes](https://github.com/phpstan/phpstan/releases/tag/0.11) and changed the code to support them. The following breaking changes were relevant:

- Type::hasProperty(), hasMethod() and hasConstant() return TrinaryLogic instead of boolean 
- In order to safely call Type::getProperty(), getMethod() or getConstant(), result of Type::hasProperty(), hasMethod() and hasConstant() respectively has to be checked for yes() first.

To fix them the only necessary change was to add a call to `yes()` on the result of `hasMethod()` and `hasProperty()`.

Fixes issue #7 