### PR TITLE
Fix reflection of inherited Repository methods

### DIFF
--- a/src/Reflection/RepositoryMethodsClassReflectionExtension.php
+++ b/src/Reflection/RepositoryMethodsClassReflectionExtension.php
@@ -7,6 +7,7 @@ use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
+use TYPO3\CMS\Core\Utility\ClassNamingUtility;
 
 class RepositoryMethodsClassReflectionExtension implements MethodsClassReflectionExtension, BrokerAwareExtension
 {
@@ -25,7 +26,22 @@ class RepositoryMethodsClassReflectionExtension implements MethodsClassReflectio
 			!$classReflection->getNativeReflection()->hasMethod($methodName)
 			&& $classReflection->isSubclassOf(\TYPO3\CMS\Extbase\Persistence\Repository::class)
 		) {
-			return strpos($methodName, 'findBy') === 0 || strpos($methodName, 'findOneBy') === 0;
+			// only handle magic find[One]By-methods
+			if (strpos($methodName, 'findBy') !== 0 && strpos($methodName, 'findOneBy') !== 0) {
+				return false;
+			}
+
+			$modelReflection = $this->broker->getClass($this->getModelName($classReflection));
+			try {
+				// and make sure, that the property actually exist in the model.
+				// phpstan checks method existence on parent classes, for each method it finds in a child class.
+				// to allow inheritance of Repositories, we need to make sure to only return true here, if that
+				// method will actually resolve to a valid findBy method on this specific class.
+				$modelReflection->getNativeProperty($this->getPropertyName($methodName))->getReadableType();
+			} catch (\PHPStan\Reflection\MissingPropertyFromReflectionException $e) {
+				return false;
+			}
+			return true;
 		}
 		return false;
 	}
@@ -39,6 +55,22 @@ class RepositoryMethodsClassReflectionExtension implements MethodsClassReflectio
 		}
 
 		return $methodReflection;
+	}
+
+	private function getModelName(ClassReflection $classReflection): string
+	{
+		$className = $classReflection->getName();
+		return ClassNamingUtility::translateRepositoryNameToModelName($className);
+	}
+
+	private function getPropertyName(string $methodName): string
+	{
+		if (strpos($methodName, 'findBy') === 0) {
+			return lcfirst(substr($methodName, 6));
+		} elseif (strpos($methodName, 'findOneBy') === 0) {
+			return lcfirst(substr($methodName, 9));
+		}
+		return $methodName;
 	}
 
 }


### PR DESCRIPTION
that start with find[One]By

When using inheritance within Repositories, and using custom findBy methods that
don't follow the naming scheme of model-properties, the previous code broke.

Suppose a structure like this:
  PostRepository

  SpecialPostRepository extends PostRepository {
    public function findByNonExistingProperty(){}
  }

Phpstan checks for the existence of every method in a child class for all parent classes
to ensure their arguments are compatible.
This leads to a hasMethod call for 'findByNonExistingProperty' on PostRepository.
Note that this class does not have a native implementation, so previously the FindByMethodReflection
was returned, despite the fact, that this property doesn't even exist.

Now we properly check for its existence beforehand and return false for hasMethod in that case