### PR TITLE
Introduce QueryResultInterface as a generic type

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -23,10 +23,21 @@ services:
         class: SaschaEgerer\PhpstanTypo3\Type\ContextDynamicReturnTypeExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
+    -
+        class: SaschaEgerer\PhpstanTypo3\Type\RepositoryQueryDynamicReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+    -
+        class: SaschaEgerer\PhpstanTypo3\Type\RepositoryFindAllDynamicReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
 parameters:
     stubFiles:
         - stubs/GeneralUtility.stub
         - stubs/ObjectStorage.stub
+        - stubs/QueryInterface.stub
+        - stubs/QueryResultInterface.stub
+        - stubs/QueryResult.stub
     dynamicConstantNames:
         - TYPO3_MODE
         - TYPO3_REQUESTTYPE

--- a/src/Type/QueryInterfaceDynamicReturnTypeExtension.php
+++ b/src/Type/QueryInterfaceDynamicReturnTypeExtension.php
@@ -8,6 +8,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
@@ -36,20 +37,21 @@ class QueryInterfaceDynamicReturnTypeExtension implements DynamicMethodReturnTyp
 		Scope $scope
 	): Type
 	{
+		$classReflection = $scope->getClassReflection();
+		$modelName = ClassNamingUtility::translateRepositoryNameToModelName(
+			$classReflection->getName()
+		);
+		
 		if (isset($methodCall->args[0])) {
 			$argType = $scope->getType($methodCall->args[0]->value);
-			$classReflection = $scope->getClassReflection();
 
 			if ($classReflection !== null && $argType instanceof ConstantBooleanType && $argType->getValue() === true) {
-				$modelName = ClassNamingUtility::translateRepositoryNameToModelName(
-					$classReflection->getName()
-				);
 
 				return new ArrayType(new IntegerType(), new ObjectType($modelName));
 			}
 		}
 
-		return new ObjectType(QueryResult::class);
+		return new GenericObjectType(QueryResult::class, [new ObjectType($modelName)]);
 	}
 
 }

--- a/src/Type/RepositoryFindAllDynamicReturnTypeExtension.php
+++ b/src/Type/RepositoryFindAllDynamicReturnTypeExtension.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace SaschaEgerer\PhpstanTypo3\Type;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use TYPO3\CMS\Core\Utility\ClassNamingUtility;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+
+class RepositoryFindAllDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return \TYPO3\CMS\Extbase\Persistence\RepositoryInterface::class;
+	}
+
+	public function isMethodSupported(
+		MethodReflection $methodReflection
+	): bool
+	{
+		return in_array($methodReflection->getName(), ['findAll'], true);
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): Type
+	{
+		$variableType = $scope->getType($methodCall->var);
+
+		if (!($variableType instanceof ObjectType) || !is_subclass_of($variableType->getClassName(), $this->getClass())) {
+			return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+		}
+
+		$modelName = ClassNamingUtility::translateRepositoryNameToModelName($variableType->getClassName());
+
+		return new GenericObjectType(QueryResultInterface::class, [new ObjectType($modelName)]);
+	}
+
+}

--- a/src/Type/RepositoryQueryDynamicReturnTypeExtension.php
+++ b/src/Type/RepositoryQueryDynamicReturnTypeExtension.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace SaschaEgerer\PhpstanTypo3\Type;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use TYPO3\CMS\Core\Utility\ClassNamingUtility;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+
+class RepositoryQueryDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return \TYPO3\CMS\Extbase\Persistence\RepositoryInterface::class;
+	}
+
+	public function isMethodSupported(
+		MethodReflection $methodReflection
+	): bool
+	{
+		return $methodReflection->getName() === 'createQuery';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): Type
+	{
+		$variableType = $scope->getType($methodCall->var);
+
+		$modelName = ClassNamingUtility::translateRepositoryNameToModelName($variableType->getClassName());
+
+		return new GenericObjectType(QueryInterface::class, [new ObjectType($modelName)]);
+	}
+
+}

--- a/stubs/QueryInterface.stub
+++ b/stubs/QueryInterface.stub
@@ -1,0 +1,20 @@
+<?php
+namespace TYPO3\CMS\Extbase\Persistence;
+
+/**
+ * @template ModelType
+ */
+interface QueryInterface
+{
+    /**
+     * @param bool $returnRawQueryResult
+     * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface<ModelType>|array<string, mixed>
+     */
+    public function execute($returnRawQueryResult = false);
+
+    /**
+     * @param mixed $constraint
+     * @return \TYPO3\CMS\Extbase\Persistence\QueryInterface<ModelType>
+     */
+    public function matching($constraint);
+}

--- a/stubs/QueryResult.stub
+++ b/stubs/QueryResult.stub
@@ -1,0 +1,13 @@
+<?php
+namespace TYPO3\CMS\Extbase\Persistence\Generic;
+
+/**
+ * @template ModelType
+ */
+class QueryResult
+{
+    /**
+     * @return ModelType
+     */
+    public function getFirst();
+}

--- a/stubs/QueryResultInterface.stub
+++ b/stubs/QueryResultInterface.stub
@@ -1,0 +1,13 @@
+<?php
+namespace TYPO3\CMS\Extbase\Persistence;
+
+/**
+ * @template ModelType
+ */
+interface QueryResultInterface
+{
+    /**
+     * @return ModelType
+     */
+    public function getFirst();
+}


### PR DESCRIPTION
This patchset makes QueryResultInterface generic.

The model type is infered from the repository, by making the QueryInterface abstract as well, This way all QueryResultInterfaces returned from a QueryInterface that is build in a Repository will be returning the correct types for PHPStan.

This works for our projects, ymmv.

The next logical step would probably be a dynamicReturnTypeExtension for QueryInterface->execute to distinguish the 'array'-case with 'returnRawQueryResult' from the QueryResultInterface-Type.