### PR TITLE
Do not fail on calls to MyRepository->findBySomePropNotInModel()

### DIFF
--- a/src/Reflection/RepositoryFindByMethodReflection.php
+++ b/src/Reflection/RepositoryFindByMethodReflection.php
@@ -82,7 +82,11 @@ class RepositoryFindByMethodReflection implements MethodReflection
 	{
 		$modelReflection = $this->broker->getClass($this->getModelName());
 
-		$type = $modelReflection->getNativeProperty($this->getPropertyName())->getReadableType();
+		if ($modelReflection->hasNativeProperty($this->getPropertyName())) {
+			$type = $modelReflection->getNativeProperty($this->getPropertyName())->getReadableType();
+		} else {
+			$type = new \PHPStan\Type\MixedType(\false);
+		}
 
 		return [
 			new RepositoryFindByParameterReflection('arg', $type),


### PR DESCRIPTION
Calling a findByXXX method on a repository tries to get the type of
the property from the model. But the reposiory does also allow findBy methods
for values that are not defined in the model but only in the database.
So if the model does not have the certain property we tread it as type mixed.