### PR TITLE
Make TYPO3 Context aspects configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ includes:
 ```
 </details>
 
+### Custom Context API Aspects
+
+If you use custom aspects for the TYPO3 Context API you can now add a mapping so PHPStan knows
+what type of aspect class is returned by the context API
+
+```
+parameters:
+    typo3:
+        contextApiGetAspectMapping:
+            myCustomAspect: \FlowdGmbh\MyProject\Context\MyCustomAspect
+```

--- a/extension.neon
+++ b/extension.neon
@@ -21,11 +21,28 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
     -
         class: SaschaEgerer\PhpstanTypo3\Type\ContextDynamicReturnTypeExtension
+        arguments:
+            contextApiGetAspectMapping: %typo3.contextApiGetAspectMapping%
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
+    -
+        class: SaschaEgerer\PhpstanTypo3\Rule\ContextAspectValidationRule
+        arguments:
+            contextApiGetAspectMapping: %typo3.contextApiGetAspectMapping%
+        tags:
+            - phpstan.rules.rule
 parameters:
     bootstrapFiles:
         - phpstan.bootstrap.php
+    typo3:
+        contextApiGetAspectMapping:
+            date: \TYPO3\CMS\Core\Context\DateTimeAspect
+            visibility: \TYPO3\CMS\Core\Context\VisibilityAspect
+            backend.user: \TYPO3\CMS\Core\Context\UserAspect
+            frontend.user: \TYPO3\CMS\Core\Context\UserAspect
+            workspace: \TYPO3\CMS\Core\Context\WorkspaceAspect
+            language: \TYPO3\CMS\Core\Context\LanguageAspect
+            typoscript: \TYPO3\CMS\Core\Context\TypoScriptAspect
     stubFiles:
         - stubs/GeneralUtility.stub
         - stubs/ObjectStorage.stub
@@ -71,3 +88,7 @@ parameters:
             - pageErrorHandler
         TYPO3\CMS\Recordlist\RecordList\DatabaseRecordList:
             - pageErrorHandler
+parametersSchema:
+    typo3: structure([
+        contextApiGetAspectMapping: arrayOf(string())
+    ])

--- a/src/Rule/ContextAspectValidationRule.php
+++ b/src/Rule/ContextAspectValidationRule.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types = 1);
+
+namespace SaschaEgerer\PhpstanTypo3\Rule;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\MethodCall>
+ */
+class ContextAspectValidationRule implements \PHPStan\Rules\Rule
+{
+
+	/** @var array<string, string> */
+	private $contextApiGetAspectMapping;
+
+	/**
+	 * @param array<string, string> $contextApiGetAspectMapping
+	 */
+	public function __construct(array $contextApiGetAspectMapping)
+	{
+		$this->contextApiGetAspectMapping = $contextApiGetAspectMapping;
+	}
+
+	public function getNodeType(): string
+	{
+		return Node\Expr\MethodCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node->name instanceof Node\Identifier) {
+			return [];
+		}
+
+		$methodReflection = $scope->getMethodReflection($scope->getType($node->var), $node->name->toString());
+		if ($methodReflection === null || $methodReflection->getName() !== 'getAspect') {
+			return [];
+		}
+
+		$declaringClass = $methodReflection->getDeclaringClass();
+
+		if ($declaringClass->getName() !== \TYPO3\CMS\Core\Context\Context::class) {
+			return [];
+		}
+
+		$argument = $node->getArgs()[0] ?? null;
+
+		if (!($argument instanceof Node\Arg) || !($argument->value instanceof Node\Scalar\String_)) {
+			return [];
+		}
+
+		if (isset($this->contextApiGetAspectMapping[$argument->value->value])) {
+			return [];
+		}
+
+		$ruleError = RuleErrorBuilder::message(sprintf(
+			'There is no aspect "%s" configured so we can\'t figure out the exact type to return when calling %s::%s',
+			$argument->value->value,
+			$declaringClass->getDisplayName(),
+			$methodReflection->getName()
+		))->tip('You should add custom aspects to the typo3.contextApiGetAspectMapping setting.')->build();
+
+		return [$ruleError];
+	}
+
+}


### PR DESCRIPTION
Add a mapping to be able to add custom Context API aspects
to the ContextDynamicReturnTypeExtension.

Resolves #34