### PR TITLE
Only override type of QueryInterface if not specified

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,17 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phing/phing": "^2.17",
-        "phpstan/phpstan-strict-rules": "^1.0"
+        "phpstan/phpstan-strict-rules": "^1.0",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {
             "SaschaEgerer\\PhpstanTypo3\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "SaschaEgerer\\PhpstanTypo3\\Tests\\": "tests/"
         }
     },
     "extra": {

--- a/extension.neon
+++ b/extension.neon
@@ -12,6 +12,10 @@ services:
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
     -
+        class: SaschaEgerer\PhpstanTypo3\Type\QueryResultToArrayDynamicReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+    -
         class: SaschaEgerer\PhpstanTypo3\Type\RepositoryDynamicReturnTypeExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension

--- a/src/Type/QueryInterfaceDynamicReturnTypeExtension.php
+++ b/src/Type/QueryInterfaceDynamicReturnTypeExtension.php
@@ -40,19 +40,27 @@ class QueryInterfaceDynamicReturnTypeExtension implements DynamicMethodReturnTyp
 		$argument = $methodCall->getArgs()[0] ?? null;
 
 		$classReflection = $scope->getClassReflection();
-		$modelName = ClassNamingUtility::translateRepositoryNameToModelName(
-			$classReflection->getName()
-		);
+
+		$queryType = $scope->getType($methodCall->var);
+		if ($queryType instanceof GenericObjectType) {
+			$modelType = $queryType->getTypes();
+		} else {
+			$modelName = ClassNamingUtility::translateRepositoryNameToModelName(
+				$classReflection->getName()
+			);
+
+			$modelType = [new ObjectType($modelName)];
+		}
 
 		if ($argument !== null) {
 			$argType = $scope->getType($argument->value);
 
 			if ($classReflection !== null && $argType instanceof ConstantBooleanType && $argType->getValue() === true) {
-				return new ArrayType(new IntegerType(), new ObjectType($modelName));
+				return new ArrayType(new IntegerType(), $modelType[0]);
 			}
 		}
 
-		return new GenericObjectType(QueryResult::class, [new ObjectType($modelName)]);
+		return new GenericObjectType(QueryResult::class, $modelType);
 	}
 
 }

--- a/src/Type/QueryResultToArrayDynamicReturnTypeExtension.php
+++ b/src/Type/QueryResultToArrayDynamicReturnTypeExtension.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace SaschaEgerer\PhpstanTypo3\Type;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use TYPO3\CMS\Core\Utility\ClassNamingUtility;
+use TYPO3\CMS\Extbase\Persistence\Generic\QueryResult;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+
+class QueryResultToArrayDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+	public function getClass(): string
+	{
+		return QueryResultInterface::class;
+	}
+
+	public function isMethodSupported(
+		MethodReflection $methodReflection
+	): bool
+	{
+		return $methodReflection->getName() === 'toArray';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): Type
+	{
+		$argument = $methodCall->getArgs()[0] ?? null;
+
+		$classReflection = $scope->getClassReflection();
+
+		$resultType = $scope->getType($methodCall->var);
+		if ($resultType instanceof GenericObjectType) {
+			$modelType = $resultType->getTypes();
+		} else {
+			$modelName = ClassNamingUtility::translateRepositoryNameToModelName(
+				$classReflection->getName()
+			);
+
+			$modelType = [new ObjectType($modelName)];
+		}
+
+		return new ArrayType(new IntegerType(), $modelType[0]);
+	}
+}

--- a/src/Type/RepositoryQueryDynamicReturnTypeExtension.php
+++ b/src/Type/RepositoryQueryDynamicReturnTypeExtension.php
@@ -37,9 +37,16 @@ class RepositoryQueryDynamicReturnTypeExtension implements DynamicMethodReturnTy
 	{
 		$variableType = $scope->getType($methodCall->var);
 
-		$modelName = ClassNamingUtility::translateRepositoryNameToModelName($variableType->getClassName());
+		$queryType = $scope->getType($methodCall->var);
+		if ($queryType instanceof GenericObjectType) {
+			$modelType = $queryType->getTypes();
+		} else {
+			$modelName = ClassNamingUtility::translateRepositoryNameToModelName($variableType->getClassName());
 
-		return new GenericObjectType(QueryInterface::class, [new ObjectType($modelName)]);
+			$modelType = [new ObjectType($modelName)];
+		}
+
+		return new GenericObjectType(QueryInterface::class, $modelType);
 	}
 
 }

--- a/tests/Unit/Type/RepositoryQueryDynamicReturnTypeExtensionTest.php
+++ b/tests/Unit/Type/RepositoryQueryDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace SaschaEgerer\PhpstanTypo3\Tests\Unit\Type;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class RepositoryQueryDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+	/**
+	 * @return iterable<mixed>
+	 */
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/custom-query-type.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [__DIR__ . '/../../../extension.neon'];
+	}
+}

--- a/tests/Unit/Type/data/custom-query-type.php
+++ b/tests/Unit/Type/data/custom-query-type.php
@@ -26,6 +26,9 @@ namespace My\Test\Extension\Domain\Repository {
 
 			$rawResult = $query->execute(true);
 			assertType('array<int, My\Test\Extension\Domain\Model\SomeOtherModel>', $rawResult);
+
+			$array = $result->toArray();
+			assertType('array<int, My\Test\Extension\Domain\Model\SomeOtherModel>', $array);
 		}
 	}
 }

--- a/tests/Unit/Type/data/custom-query-type.php
+++ b/tests/Unit/Type/data/custom-query-type.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace My\Test\Extension\Domain\Model {
+	use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+
+	// Extbase naming convention says this model should be called MyModel, but we want to test that it also works if we
+	// have a different model name
+	class SomeOtherModel extends AbstractEntity {}
+}
+
+namespace My\Test\Extension\Domain\Repository {
+
+	use My\Test\Extension\Domain\Model\SomeOtherModel;
+	use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+	use function PHPStan\Testing\assertType;
+
+	class MyModelRepository extends \TYPO3\CMS\Extbase\Persistence\Repository {
+		public function findBySomething()
+		{
+			/** @var QueryInterface<SomeOtherModel> $query */
+			$query = $this->persistenceManager->createQueryForType(SomeOtherModel::class);
+
+			$result = $query->execute();
+			assertType('TYPO3\CMS\Extbase\Persistence\QueryInterface<My\Test\Extension\Domain\Model\SomeOtherModel>', $query);
+
+			$rawResult = $query->execute(true);
+			assertType('array<int, My\Test\Extension\Domain\Model\SomeOtherModel>', $rawResult);
+		}
+	}
+}


### PR DESCRIPTION
This keeps the inferred/declared type of `QueryInterface` and `QueryResultInterface`, if they are already a `GenericObjectType`.

This way, it's possible to not follow the Extbase naming conventions (for whatever reason) and still have correct type analysis results by PhpStan.

Additionally, the changes are covered by Unit tests (which should probably be included in the Travis pipeline).