### PR TITLE
Fix return type of repository findBy methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,10 @@
     "autoload-dev": {
         "psr-4": {
             "SaschaEgerer\\PhpstanTypo3\\Tests\\": "tests/"
-        }
+        },
+        "files": [
+            "tests/Unit/Type/data/repository-stub-files.php"
+        ]
     },
     "extra": {
         "branch-alias": {
@@ -37,6 +40,13 @@
         },
         "phpstan": {
             "includes": ["extension.neon"]
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true
         }
     }
 }

--- a/src/Reflection/RepositoryFindByMethodReflection.php
+++ b/src/Reflection/RepositoryFindByMethodReflection.php
@@ -8,9 +8,9 @@ use PHPStan\Reflection\FunctionVariant;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\ObjectType;
-use PHPStan\Type\Type;
 use TYPO3\CMS\Core\Utility\ClassNamingUtility;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
@@ -98,9 +98,9 @@ class RepositoryFindByMethodReflection implements MethodReflection
 		return false;
 	}
 
-	public function getReturnType(): Type
+	public function getReturnType(): GenericObjectType
 	{
-		return new ObjectType(QueryResultInterface::class);
+		return new GenericObjectType(QueryResultInterface::class, [new ObjectType($this->getModelName())]);
 	}
 
 	/**

--- a/tests/Unit/Type/data/repository-stub-files.php
+++ b/tests/Unit/Type/data/repository-stub-files.php
@@ -23,6 +23,47 @@ namespace RepositoryStubFiles\My\Test\Extension\Domain\Repository {
 				'class-string<static(RepositoryStubFiles\My\Test\Extension\Domain\Repository\MyModelRepository)>',
 				$this->getRepositoryClassName()
 			);
+
+			assertType(
+				'TYPO3\CMS\Extbase\Persistence\QueryResultInterface<RepositoryStubFiles\My\Test\Extension\Domain\Model\MyModel>',
+				$this->findAll()
+			);
+
+			assertType(
+				'TYPO3\CMS\Extbase\Persistence\QueryResultInterface<RepositoryStubFiles\My\Test\Extension\Domain\Model\MyModel>',
+				$this->findByFoo()
+			);
+
+			assertType(
+				'RepositoryStubFiles\My\Test\Extension\Domain\Model\MyModel|null',
+				$this->findOneByFoo()
+			);
+
+			assertType(
+				'array<int, RepositoryStubFiles\My\Test\Extension\Domain\Model\MyModel>',
+				$this->findByFoo()->toArray()
+			);
+
+			assertType(
+				'int',
+				$this->countByFoo()
+			);
+
+			assertType(
+				'int',
+				$this->countByFoo('a')
+			);
 		}
 	}
+
+    class MyModelWithoutExtendsRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
+    {
+        public function __construct()
+        {
+            assertType(
+                'TYPO3\CMS\Extbase\Persistence\QueryResultInterface<TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface>',
+                $this->findAll()
+            );
+        }
+    }
 }


### PR DESCRIPTION
The FooRepository->findByProperty() function must return an
`QueryResultInterface<Foo>` type.

Tests have also been added for that case.