### PR TITLE
[BUGFIX] Add array as return type for Repository::findAll()

### DIFF
--- a/stubs/Repository.stub
+++ b/stubs/Repository.stub
@@ -30,7 +30,7 @@ class Repository
     public function update($modifiedObject);
 
     /**
-     * @phpstan-return QueryResultInterface<TEntityClass>
+     * @phpstan-return QueryResultInterface<TEntityClass>|list<TEntityClass>
      */
     public function findAll();
 

--- a/tests/Unit/Type/data/repository-stub-files.php
+++ b/tests/Unit/Type/data/repository-stub-files.php
@@ -25,7 +25,7 @@ namespace RepositoryStubFiles\My\Test\Extension\Domain\Repository {
 			);
 
 			assertType(
-				'TYPO3\CMS\Extbase\Persistence\QueryResultInterface<RepositoryStubFiles\My\Test\Extension\Domain\Model\MyModel>',
+				'array<int, RepositoryStubFiles\My\Test\Extension\Domain\Model\MyModel>|TYPO3\CMS\Extbase\Persistence\QueryResultInterface<RepositoryStubFiles\My\Test\Extension\Domain\Model\MyModel>',
 				$this->findAll()
 			);
 
@@ -61,7 +61,7 @@ namespace RepositoryStubFiles\My\Test\Extension\Domain\Repository {
         public function __construct()
         {
             assertType(
-                'TYPO3\CMS\Extbase\Persistence\QueryResultInterface<TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface>',
+                'array<int, TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface>|TYPO3\CMS\Extbase\Persistence\QueryResultInterface<TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface>',
                 $this->findAll()
             );
         }


### PR DESCRIPTION
Extbase typehints the return value of `Repository::findAll()` as `QueryResultInterface|array`. For repositories overwriting said method, it is possible to explicitly return an array of objects. Since the related stub file does not cover this case, the appropriate typehint has now been added.

References:

* https://github.com/TYPO3/typo3/blob/3d600e4e3b7682ffb3778cba24e6ee826a2fb353/typo3/sysext/extbase/Classes/Persistence/Repository.php#L114