### PR TITLE
Add possibility to define array return type for Repository->findAll

### DIFF
--- a/src/Type/RepositoryFindAllDynamicReturnTypeExtension.php
+++ b/src/Type/RepositoryFindAllDynamicReturnTypeExtension.php
@@ -10,8 +10,10 @@ use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeWithClassName;
 use TYPO3\CMS\Core\Utility\ClassNamingUtility;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+use TYPO3\CMS\Extbase\Persistence\Repository;
 
 class RepositoryFindAllDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -36,7 +38,7 @@ class RepositoryFindAllDynamicReturnTypeExtension implements DynamicMethodReturn
 	{
 		$variableType = $scope->getType($methodCall->var);
 
-		if (!($variableType instanceof ObjectType) || !is_subclass_of($variableType->getClassName(), $this->getClass())) {
+		if ($methodReflection->getDeclaringClass()->getName() !== Repository::class || !$variableType instanceof TypeWithClassName) {
 			return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 		}
 

--- a/stubs/Repository.stub
+++ b/stubs/Repository.stub
@@ -30,7 +30,7 @@ class Repository
     public function update($modifiedObject);
 
     /**
-     * @phpstan-return QueryResultInterface<TEntityClass>
+     * @phpstan-return QueryResultInterface<TEntityClass>|list<TEntityClass>
      */
     public function findAll();
 

--- a/tests/Unit/Type/data/repository-stub-files.php
+++ b/tests/Unit/Type/data/repository-stub-files.php
@@ -59,16 +59,43 @@ class MyModelRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 
 }
 
-	/** @phpstan-ignore-next-line */
+class MyModelWithoutExtends extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
+{
+
+}
+
+/** @phpstan-ignore-next-line */
 class MyModelWithoutExtendsRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 {
 
 	public function myTests(): void
 	{
 		assertType(
-			'TYPO3\CMS\Extbase\Persistence\QueryResultInterface<TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface>',
+			'TYPO3\CMS\Extbase\Persistence\QueryResultInterface<RepositoryStubFiles\My\Test\Extension\Domain\Model\MyModelWithoutExtends>',
 			$this->findAll()
 		);
+	}
+
+}
+
+/** @extends \TYPO3\CMS\Extbase\Persistence\Repository<\RepositoryStubFiles\My\Test\Extension\Domain\Model\MyModel> */
+class FindAllTestRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
+{
+
+	public function myTests(): void
+	{
+		assertType(
+			'array<int, RepositoryStubFiles\My\Test\Extension\Domain\Model\MyModel>',
+			$this->findAll()
+		);
+	}
+
+	/**
+	 * @return list<\RepositoryStubFiles\My\Test\Extension\Domain\Model\MyModel>
+	 */
+	public function findAll(): array
+	{
+		return [];
 	}
 
 }


### PR DESCRIPTION
The RepositoryFindAllDynamicReturnTypeExtension does now check where
the findAll method is defined. If it is not overwritten but defined
in the native Repository class, the default behavior, returning a
QueryResultInterface, will be used. If the findAll method is overwritten,
the declaration from that overwrite will be used.
The Repository.stub has been adjusted to now also support and array as
return type for findAll.