### PR TITLE
forwardToReferringRequest is not always exiting

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -92,7 +92,6 @@ parameters:
             - redirectToUri
             - redirect
             - forward
-            - forwardToReferringRequest
             - throwStatus
         TYPO3\CMS\Core\Utility\HttpUtility:
             - redirect


### PR DESCRIPTION
Technically the method forwardToReferringRequest is not always terminating only if a referringRequest exists.