### PR TITLE
Require phpstan ^1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.2 || ^8.0",
-        "phpstan/phpstan": "^1.1",
+        "phpstan/phpstan": "^1.6",
         "nikic/php-parser": ">= 4.13",
         "typo3/cms-core": "^8.7 || ^9.5 || ^10.4 || ^11.2",
         "typo3/cms-extbase": "^8.7 || ^9.5 || ^10.4 || ^11.2"

--- a/src/Helpers/Typo3ClassNamingUtilityTrait.php
+++ b/src/Helpers/Typo3ClassNamingUtilityTrait.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+/**
+ * We can't use SaschaEgerer\PhpstanTypo3\Trait as namespace
+ * as keywords like "Trait" are not allowed in namespaces until PHP 8.0
+ */
+
+namespace SaschaEgerer\PhpstanTypo3\Helpers;
+
+use TYPO3\CMS\Core\Utility\ClassNamingUtility;
+use TYPO3\CMS\Extbase\Persistence\RepositoryInterface;
+
+trait Typo3ClassNamingUtilityTrait
+{
+
+	/**
+	 * @param class-string $repositoryClassName
+	 * @return class-string
+	 */
+	protected function translateRepositoryNameToModelName(string $repositoryClassName): string
+	{
+		if (is_a(RepositoryInterface::class, $repositoryClassName, true)) {
+			throw new \PHPStan\ShouldNotHappenException('Repository class must implement RepositoryInterface');
+		}
+		/** @var class-string<RepositoryInterface> $repositoryClassName */
+
+		/** @var class-string $modelName */
+		$modelName = ClassNamingUtility::translateRepositoryNameToModelName($repositoryClassName);
+		return $modelName;
+	}
+
+}

--- a/src/Reflection/RepositoryCountByMethodsClassReflectionExtension.php
+++ b/src/Reflection/RepositoryCountByMethodsClassReflectionExtension.php
@@ -6,11 +6,13 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\ReflectionProvider;
-use TYPO3\CMS\Core\Utility\ClassNamingUtility;
+use SaschaEgerer\PhpstanTypo3\Helpers\Typo3ClassNamingUtilityTrait;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 class RepositoryCountByMethodsClassReflectionExtension implements MethodsClassReflectionExtension
 {
+
+	use Typo3ClassNamingUtilityTrait;
 
 	/** @var ReflectionProvider */
 	private $reflectionProvider;
@@ -40,7 +42,7 @@ class RepositoryCountByMethodsClassReflectionExtension implements MethodsClassRe
 		// be methods starting with find[One]By... with custom implementations on
 		// inherited repositories
 		$className = $classReflection->getName();
-		$modelName = ClassNamingUtility::translateRepositoryNameToModelName($className);
+		$modelName = $this->translateRepositoryNameToModelName($className);
 
 		$modelReflection = $this->reflectionProvider->getClass($modelName);
 		if (!$modelReflection->hasProperty($propertyName)) {

--- a/src/Reflection/RepositoryFindByMethodReflection.php
+++ b/src/Reflection/RepositoryFindByMethodReflection.php
@@ -11,11 +11,13 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\ObjectType;
-use TYPO3\CMS\Core\Utility\ClassNamingUtility;
+use SaschaEgerer\PhpstanTypo3\Helpers\Typo3ClassNamingUtilityTrait;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
 class RepositoryFindByMethodReflection implements MethodReflection
 {
+
+	use Typo3ClassNamingUtilityTrait;
 
 	/** @var \PHPStan\Reflection\ClassReflection */
 	private $classReflection;
@@ -68,11 +70,13 @@ class RepositoryFindByMethodReflection implements MethodReflection
 		return lcfirst(substr($this->getName(), 6));
 	}
 
+	/**
+	 * @return class-string
+	 */
 	private function getModelName(): string
 	{
 		$className = $this->classReflection->getName();
-
-		return ClassNamingUtility::translateRepositoryNameToModelName($className);
+		return $this->translateRepositoryNameToModelName($className);
 	}
 
 	/**

--- a/src/Reflection/RepositoryFindMethodsClassReflectionExtension.php
+++ b/src/Reflection/RepositoryFindMethodsClassReflectionExtension.php
@@ -6,11 +6,13 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\ReflectionProvider;
-use TYPO3\CMS\Core\Utility\ClassNamingUtility;
+use SaschaEgerer\PhpstanTypo3\Helpers\Typo3ClassNamingUtilityTrait;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 class RepositoryFindMethodsClassReflectionExtension implements MethodsClassReflectionExtension
 {
+
+	use Typo3ClassNamingUtilityTrait;
 
 	/** @var ReflectionProvider $reflectionProvider */
 	private $reflectionProvider;
@@ -44,7 +46,7 @@ class RepositoryFindMethodsClassReflectionExtension implements MethodsClassRefle
 		// be methods starting with find[One]By... with custom implementations on
 		// inherited repositories
 		$className = $classReflection->getName();
-		$modelName = ClassNamingUtility::translateRepositoryNameToModelName($className);
+		$modelName = $this->translateRepositoryNameToModelName($className);
 
 		$modelReflection = $this->reflectionProvider->getClass($modelName);
 		if (!$modelReflection->hasProperty($propertyName)) {

--- a/src/Reflection/RepositoryFindOneByMethodReflection.php
+++ b/src/Reflection/RepositoryFindOneByMethodReflection.php
@@ -12,10 +12,12 @@ use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use TYPO3\CMS\Core\Utility\ClassNamingUtility;
+use SaschaEgerer\PhpstanTypo3\Helpers\Typo3ClassNamingUtilityTrait;
 
 class RepositoryFindOneByMethodReflection implements MethodReflection
 {
+
+	use Typo3ClassNamingUtilityTrait;
 
 	/** @var \PHPStan\Reflection\ClassReflection */
 	private $classReflection;
@@ -68,11 +70,14 @@ class RepositoryFindOneByMethodReflection implements MethodReflection
 		return lcfirst(substr($this->getName(), 9));
 	}
 
+	/**
+	 * @return class-string
+	 */
 	private function getModelName(): string
 	{
 		$className = $this->classReflection->getName();
 
-		return ClassNamingUtility::translateRepositoryNameToModelName($className);
+		return $this->translateRepositoryNameToModelName($className);
 	}
 
 	/**

--- a/src/Type/QueryInterfaceDynamicReturnTypeExtension.php
+++ b/src/Type/QueryInterfaceDynamicReturnTypeExtension.php
@@ -13,12 +13,14 @@ use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
-use TYPO3\CMS\Core\Utility\ClassNamingUtility;
+use SaschaEgerer\PhpstanTypo3\Helpers\Typo3ClassNamingUtilityTrait;
 use TYPO3\CMS\Extbase\Persistence\Generic\QueryResult;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 
 class QueryInterfaceDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
+
+	use Typo3ClassNamingUtilityTrait;
 
 	public function getClass(): string
 	{
@@ -50,7 +52,7 @@ class QueryInterfaceDynamicReturnTypeExtension implements DynamicMethodReturnTyp
 				return new ErrorType();
 			}
 
-			$modelName = ClassNamingUtility::translateRepositoryNameToModelName(
+			$modelName = $this->translateRepositoryNameToModelName(
 				$classReflection->getName()
 			);
 

--- a/src/Type/QueryResultToArrayDynamicReturnTypeExtension.php
+++ b/src/Type/QueryResultToArrayDynamicReturnTypeExtension.php
@@ -12,11 +12,13 @@ use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
-use TYPO3\CMS\Core\Utility\ClassNamingUtility;
+use SaschaEgerer\PhpstanTypo3\Helpers\Typo3ClassNamingUtilityTrait;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
 class QueryResultToArrayDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
+
+	use Typo3ClassNamingUtilityTrait;
 
 	public function getClass(): string
 	{
@@ -46,7 +48,7 @@ class QueryResultToArrayDynamicReturnTypeExtension implements DynamicMethodRetur
 				return new ErrorType();
 			}
 
-			$modelName = ClassNamingUtility::translateRepositoryNameToModelName(
+			$modelName = $this->translateRepositoryNameToModelName(
 				$classReflection->getName()
 			);
 

--- a/src/Type/RepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/RepositoryDynamicReturnTypeExtension.php
@@ -10,10 +10,12 @@ use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use TYPO3\CMS\Core\Utility\ClassNamingUtility;
+use SaschaEgerer\PhpstanTypo3\Helpers\Typo3ClassNamingUtilityTrait;
 
 class RepositoryDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
+
+	use Typo3ClassNamingUtilityTrait;
 
 	public function getClass(): string
 	{
@@ -39,7 +41,7 @@ class RepositoryDynamicReturnTypeExtension implements DynamicMethodReturnTypeExt
 			return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 		}
 
-		$modelName = ClassNamingUtility::translateRepositoryNameToModelName($variableType->getClassName());
+		$modelName = $this->translateRepositoryNameToModelName($variableType->getClassName());
 
 		return TypeCombinator::addNull(new ObjectType($modelName));
 	}

--- a/src/Type/RepositoryFindAllDynamicReturnTypeExtension.php
+++ b/src/Type/RepositoryFindAllDynamicReturnTypeExtension.php
@@ -11,12 +11,14 @@ use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
-use TYPO3\CMS\Core\Utility\ClassNamingUtility;
+use SaschaEgerer\PhpstanTypo3\Helpers\Typo3ClassNamingUtilityTrait;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 class RepositoryFindAllDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
+
+	use Typo3ClassNamingUtilityTrait;
 
 	public function getClass(): string
 	{
@@ -42,7 +44,10 @@ class RepositoryFindAllDynamicReturnTypeExtension implements DynamicMethodReturn
 			return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 		}
 
-		$modelName = ClassNamingUtility::translateRepositoryNameToModelName($variableType->getClassName());
+		/** @var class-string $className */
+		$className = $variableType->getClassName();
+
+		$modelName = $this->translateRepositoryNameToModelName($className);
 
 		return new GenericObjectType(QueryResultInterface::class, [new ObjectType($modelName)]);
 	}

--- a/src/Type/RepositoryQueryDynamicReturnTypeExtension.php
+++ b/src/Type/RepositoryQueryDynamicReturnTypeExtension.php
@@ -11,11 +11,13 @@ use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
-use TYPO3\CMS\Core\Utility\ClassNamingUtility;
+use SaschaEgerer\PhpstanTypo3\Helpers\Typo3ClassNamingUtilityTrait;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 
 class RepositoryQueryDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
+
+	use Typo3ClassNamingUtilityTrait;
 
 	public function getClass(): string
 	{
@@ -45,7 +47,10 @@ class RepositoryQueryDynamicReturnTypeExtension implements DynamicMethodReturnTy
 				return new ErrorType();
 			}
 
-			$modelName = ClassNamingUtility::translateRepositoryNameToModelName($variableType->getClassName());
+			/** @var class-string $className */
+			$className = $variableType->getClassName();
+
+			$modelName = $this->translateRepositoryNameToModelName($className);
 
 			$modelType = [new ObjectType($modelName)];
 		}


### PR DESCRIPTION
To be able to use conditional return types we need to update
the minumum phpstan version to be 1.6.
See https://phpstan.org/blog/phpstan-1-6-0-with-conditional-return-types