### PR TITLE
Fix invalid condition in Typo3ClassNamingUtilityTrait

### DIFF
--- a/src/Helpers/Typo3ClassNamingUtilityTrait.php
+++ b/src/Helpers/Typo3ClassNamingUtilityTrait.php
@@ -19,14 +19,14 @@ trait Typo3ClassNamingUtilityTrait
 	 */
 	protected function translateRepositoryNameToModelName(string $repositoryClassName): string
 	{
-		if (is_a(RepositoryInterface::class, $repositoryClassName, true)) {
-			throw new \PHPStan\ShouldNotHappenException('Repository class must implement RepositoryInterface');
+		if (!is_a($repositoryClassName, RepositoryInterface::class, true)) {
+			throw new \PHPStan\ShouldNotHappenException(
+				sprintf('Repository class "%s" must implement "%s"', $repositoryClassName, RepositoryInterface::class)
+			);
 		}
-		/** @var class-string<RepositoryInterface> $repositoryClassName */
-
-		/** @var class-string $modelName */
-		$modelName = ClassNamingUtility::translateRepositoryNameToModelName($repositoryClassName);
-		return $modelName;
+		/** @var class-string $modelClass */
+		$modelClass = ClassNamingUtility::translateRepositoryNameToModelName($repositoryClassName);
+		return $modelClass;
 	}
 
 }


### PR DESCRIPTION
There have been multiple issues in the condition
that does check if the given class does implement the
RepositoryInterface when converting the repository name
to a model name.

1. The condition was not negated
2. The attributes passed to "is_a()" where in the wrong or order.

So the condition was totally broken and did not do what it should do.