### PR TITLE
Allow more complex phpdoc types in mappings and add more tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ what type of class is returned by Request::getAttribute()
 ```
 parameters:
     typo3:
-        requestApiGetAttributeMapping:
+        requestGetAttributeMapping:
             myAttribute: FlowdGmbh\MyProject\Http\MyAttribute
+            myNullableAttribute: FlowdGmbh\MyProject\Http\MyAttribute|null
 ```
 
 ```

--- a/extension.neon
+++ b/extension.neon
@@ -80,6 +80,7 @@ parameters:
             normalizedParams: TYPO3\CMS\Core\Http\NormalizedParams
             site: TYPO3\CMS\Core\Site\Entity\Site
             applicationType: TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_*
+            routing: TYPO3\CMS\Core\Routing\SiteRouteResult|TYPO3\CMS\Core\Routing\PageArguments
     stubFiles:
         - stubs/DomainObjectInterface.stub
         - stubs/GeneralUtility.stub

--- a/extension.neon
+++ b/extension.neon
@@ -40,6 +40,12 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: SaschaEgerer\PhpstanTypo3\Rule\RequestAttributeValidationRule
+        arguments:
+            requestGetAttributeMapping: %typo3.requestGetAttributeMapping%
+        tags:
+            - phpstan.rules.rule
+    -
         class: SaschaEgerer\PhpstanTypo3\Type\RepositoryQueryDynamicReturnTypeExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
@@ -50,7 +56,7 @@ services:
     -
         class: SaschaEgerer\PhpstanTypo3\Type\RequestDynamicReturnTypeExtension
         arguments:
-            requestApiGetAttributeMapping: %typo3.requestApiGetAttributeMapping%
+            requestGetAttributeMapping: %typo3.requestGetAttributeMapping%
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 parameters:
@@ -65,7 +71,7 @@ parameters:
             workspace: TYPO3\CMS\Core\Context\WorkspaceAspect
             language: TYPO3\CMS\Core\Context\LanguageAspect
             typoscript: TYPO3\CMS\Core\Context\TypoScriptAspect
-        requestApiGetAttributeMapping:
+        requestGetAttributeMapping:
             backend.user: TYPO3\CMS\Backend\FrontendBackendUserAuthentication
             frontend.user: TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication
             language: TYPO3\CMS\Core\Site\Entity\SiteLanguage
@@ -126,5 +132,5 @@ parameters:
 parametersSchema:
     typo3: structure([
         contextApiGetAspectMapping: arrayOf(string())
-        requestApiGetAttributeMapping: arrayOf(string())
+        requestGetAttributeMapping: arrayOf(string())
     ])

--- a/extension.neon
+++ b/extension.neon
@@ -79,6 +79,7 @@ parameters:
             moduleData: TYPO3\CMS\Backend\Module\ModuleData
             normalizedParams: TYPO3\CMS\Core\Http\NormalizedParams
             site: TYPO3\CMS\Core\Site\Entity\Site
+            applicationType: TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_*
     stubFiles:
         - stubs/DomainObjectInterface.stub
         - stubs/GeneralUtility.stub

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,8 @@
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon
     - extension.neon
+    - tests/Unit/Type/data/context-get-aspect-return-types.neon
+    - tests/Unit/Type/data/request-get-attribute-return-types.neon
 
 parameters:
     level: 8

--- a/src/Rule/RequestAttributeValidationRule.php
+++ b/src/Rule/RequestAttributeValidationRule.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types = 1);
+
+namespace SaschaEgerer\PhpstanTypo3\Rule;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleErrorBuilder;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\MethodCall>
+ */
+class RequestAttributeValidationRule implements \PHPStan\Rules\Rule
+{
+
+	/** @var array<string, string> */
+	private $requestGetAttributeMapping;
+
+	/**
+	 * @param array<string, string> $requestGetAttributeMapping
+	 */
+	public function __construct(array $requestGetAttributeMapping)
+	{
+		$this->requestGetAttributeMapping = $requestGetAttributeMapping;
+	}
+
+	public function getNodeType(): string
+	{
+		return Node\Expr\MethodCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node->name instanceof Node\Identifier) {
+			return [];
+		}
+
+		$methodReflection = $scope->getMethodReflection($scope->getType($node->var), $node->name->toString());
+		if ($methodReflection === null || $methodReflection->getName() !== 'getAttribute') {
+			return [];
+		}
+
+		$declaringClass = $methodReflection->getDeclaringClass();
+
+		if (!$declaringClass->implementsInterface(ServerRequestInterface::class) && $declaringClass->getName() !== ServerRequestInterface::class) {
+			return [];
+		}
+
+		$argument = $node->getArgs()[0] ?? null;
+
+		if (!($argument instanceof Node\Arg) || !($argument->value instanceof Node\Scalar\String_)) {
+			return [];
+		}
+
+		if (isset($this->requestGetAttributeMapping[$argument->value->value])) {
+			return [];
+		}
+
+		$ruleError = RuleErrorBuilder::message(sprintf(
+			'There is no request attribute "%s" configured so we can\'t figure out the exact type to return when calling %s::%s',
+			$argument->value->value,
+			$declaringClass->getDisplayName(),
+			$methodReflection->getName()
+		))->tip('You should add custom request attribute to the typo3.requestGetAttributeMapping setting.')->build();
+
+		return [$ruleError];
+	}
+
+}

--- a/src/Type/ContextDynamicReturnTypeExtension.php
+++ b/src/Type/ContextDynamicReturnTypeExtension.php
@@ -4,10 +4,10 @@ namespace SaschaEgerer\PhpstanTypo3\Type;
 
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
 class ContextDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
@@ -16,12 +16,16 @@ class ContextDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtens
 	/** @var array<string, string> */
 	private $contextApiGetAspectMapping;
 
+	/** @var TypeStringResolver */
+	private $typeStringResolver;
+
 	/**
 	 * @param array<string, string> $contextApiGetAspectMapping
 	 */
-	public function __construct(array $contextApiGetAspectMapping)
+	public function __construct(array $contextApiGetAspectMapping, TypeStringResolver $typeStringResolver)
 	{
 		$this->contextApiGetAspectMapping = $contextApiGetAspectMapping;
+		$this->typeStringResolver = $typeStringResolver;
 	}
 
 	public function getClass(): string
@@ -49,7 +53,7 @@ class ContextDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtens
 		}
 
 		if (isset($this->contextApiGetAspectMapping[$argument->value->value])) {
-			return new ObjectType($this->contextApiGetAspectMapping[$argument->value->value]);
+			return $this->typeStringResolver->resolve($this->contextApiGetAspectMapping[$argument->value->value]);
 		}
 
 		return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();

--- a/src/Type/RequestDynamicReturnTypeExtension.php
+++ b/src/Type/RequestDynamicReturnTypeExtension.php
@@ -9,6 +9,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 
 class RequestDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -46,7 +47,7 @@ class RequestDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtens
 		}
 
 		if (isset($this->requestGetAttributeMapping[$argument->value->value])) {
-			return $this->typeStringResolver->resolve($this->requestGetAttributeMapping[$argument->value->value]);
+			return TypeCombinator::addNull($this->typeStringResolver->resolve($this->requestGetAttributeMapping[$argument->value->value]));
 		}
 
 		return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();

--- a/src/Type/RequestDynamicReturnTypeExtension.php
+++ b/src/Type/RequestDynamicReturnTypeExtension.php
@@ -4,24 +4,28 @@ namespace SaschaEgerer\PhpstanTypo3\Type;
 
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
 class RequestDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
 
 	/** @var array<string, string> */
-	private $requestApiGetAttributeMapping;
+	private $requestGetAttributeMapping;
+
+	/** @var TypeStringResolver */
+	private $typeStringResolver;
 
 	/**
-	 * @param array<string, string> $requestApiGetAttributeMapping
+	 * @param array<string, string> $requestGetAttributeMapping
 	 */
-	public function __construct(array $requestApiGetAttributeMapping)
+	public function __construct(array $requestGetAttributeMapping, TypeStringResolver $typeStringResolver)
 	{
-		$this->requestApiGetAttributeMapping = $requestApiGetAttributeMapping;
+		$this->requestGetAttributeMapping = $requestGetAttributeMapping;
+		$this->typeStringResolver = $typeStringResolver;
 	}
 
 	public function getClass(): string
@@ -41,8 +45,8 @@ class RequestDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtens
 			return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 		}
 
-		if (isset($this->requestApiGetAttributeMapping[$argument->value->value])) {
-			return new ObjectType($this->requestApiGetAttributeMapping[$argument->value->value]);
+		if (isset($this->requestGetAttributeMapping[$argument->value->value])) {
+			return $this->typeStringResolver->resolve($this->requestGetAttributeMapping[$argument->value->value]);
 		}
 
 		return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();

--- a/tests/Unit/Type/RequestGetAttributeDynamicReturnTypeExtensionTest.php
+++ b/tests/Unit/Type/RequestGetAttributeDynamicReturnTypeExtensionTest.php
@@ -4,7 +4,7 @@ namespace SaschaEgerer\PhpstanTypo3\Tests\Unit\Type;
 
 use PHPStan\Testing\TypeInferenceTestCase;
 
-class ContextDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
+class RequestGetAttributeDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
 {
 
 	/**
@@ -13,7 +13,7 @@ class ContextDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
 	public function dataFileAsserts(): iterable
 	{
 		// path to a file with actual asserts of expected types:
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/context-get-aspect-return-types.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/request-get-attribute-return-types.php');
 	}
 
 	/**
@@ -35,7 +35,7 @@ class ContextDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
 	{
 		return [
 			__DIR__ . '/../../../extension.neon',
-			__DIR__ . '/data/context-get-aspect-return-types.neon',
+			__DIR__ . '/data/request-get-attribute-return-types.neon',
 		];
 	}
 

--- a/tests/Unit/Type/data/context-get-aspect-return-types.neon
+++ b/tests/Unit/Type/data/context-get-aspect-return-types.neon
@@ -1,0 +1,4 @@
+parameters:
+    typo3:
+        contextApiGetAspectMapping:
+            myCustomAspect: Foo\Bar|TYPO3\CMS\Core\Context\DateTimeAspect

--- a/tests/Unit/Type/data/context-get-aspect-return-types.php
+++ b/tests/Unit/Type/data/context-get-aspect-return-types.php
@@ -27,6 +27,7 @@ class MyContext
 		assertType(UserAspect::class, $context->getAspect('frontend.user'));
 		assertType(WorkspaceAspect::class, $context->getAspect('workspace'));
 		assertType(LanguageAspect::class, $context->getAspect('language'));
+		assertType('Foo\Bar|TYPO3\CMS\Core\Context\DateTimeAspect', $context->getAspect('myCustomAspect'));
 	}
 
 }

--- a/tests/Unit/Type/data/request-get-attribute-return-types.neon
+++ b/tests/Unit/Type/data/request-get-attribute-return-types.neon
@@ -1,0 +1,5 @@
+parameters:
+    typo3:
+        requestGetAttributeMapping:
+            myCustomAttribute: FlowdGmbh\MyProject\Http\MyAttribute
+            myCustomNullableAttribute: FlowdGmbh\MyProject\Http\MyAttribute|null

--- a/tests/Unit/Type/data/request-get-attribute-return-types.neon
+++ b/tests/Unit/Type/data/request-get-attribute-return-types.neon
@@ -2,4 +2,4 @@ parameters:
     typo3:
         requestGetAttributeMapping:
             myCustomAttribute: FlowdGmbh\MyProject\Http\MyAttribute
-            myCustomNullableAttribute: FlowdGmbh\MyProject\Http\MyAttribute|null
+            myCustomThatCanBeIntAttribute: FlowdGmbh\MyProject\Http\MyAttribute|int

--- a/tests/Unit/Type/data/request-get-attribute-return-types.php
+++ b/tests/Unit/Type/data/request-get-attribute-return-types.php
@@ -14,6 +14,9 @@ class MyRequest
 
 	public function getAttributeTests(ServerRequestInterface $request): void
 	{
+		if (class_exists(\TYPO3\CMS\Core\Routing\SiteRouteResult::class) && class_exists(\TYPO3\CMS\Core\Routing\PageArguments::class)) {
+			assertType(\TYPO3\CMS\Core\Routing\PageArguments::class . '|' . \TYPO3\CMS\Core\Routing\SiteRouteResult::class . '|null', $request->getAttribute('routing'));
+		}
 		assertType(SiteLanguage::class . '|null', $request->getAttribute('language'));
 		assertType(Site::class . '|null', $request->getAttribute('site'));
 		assertType(NormalizedParams::class . '|null', $request->getAttribute('normalizedParams'));

--- a/tests/Unit/Type/data/request-get-attribute-return-types.php
+++ b/tests/Unit/Type/data/request-get-attribute-return-types.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace RequestGetAttributeReturnTypes;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\NormalizedParams;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use function PHPStan\Testing\assertType;
+
+// phpcs:ignore Squiz.Classes.ClassFileName.NoMatch
+class MyRequest
+{
+
+	public function getAttributeTests(ServerRequestInterface $request): void
+	{
+		assertType(SiteLanguage::class, $request->getAttribute('language'));
+		assertType(Site::class, $request->getAttribute('site'));
+		assertType(NormalizedParams::class, $request->getAttribute('normalizedParams'));
+		assertType('FlowdGmbh\\MyProject\\Http\\MyAttribute', $request->getAttribute('myCustomAttribute'));
+		assertType('FlowdGmbh\\MyProject\\Http\\MyAttribute|null', $request->getAttribute('myCustomNullableAttribute'));
+	}
+
+}

--- a/tests/Unit/Type/data/request-get-attribute-return-types.php
+++ b/tests/Unit/Type/data/request-get-attribute-return-types.php
@@ -17,6 +17,7 @@ class MyRequest
 		assertType(SiteLanguage::class, $request->getAttribute('language'));
 		assertType(Site::class, $request->getAttribute('site'));
 		assertType(NormalizedParams::class, $request->getAttribute('normalizedParams'));
+		assertType('1|2|4|8|16', $request->getAttribute('applicationType'));
 		assertType('FlowdGmbh\\MyProject\\Http\\MyAttribute', $request->getAttribute('myCustomAttribute'));
 		assertType('FlowdGmbh\\MyProject\\Http\\MyAttribute|null', $request->getAttribute('myCustomNullableAttribute'));
 	}

--- a/tests/Unit/Type/data/request-get-attribute-return-types.php
+++ b/tests/Unit/Type/data/request-get-attribute-return-types.php
@@ -14,12 +14,12 @@ class MyRequest
 
 	public function getAttributeTests(ServerRequestInterface $request): void
 	{
-		assertType(SiteLanguage::class, $request->getAttribute('language'));
-		assertType(Site::class, $request->getAttribute('site'));
-		assertType(NormalizedParams::class, $request->getAttribute('normalizedParams'));
-		assertType('1|2|4|8|16', $request->getAttribute('applicationType'));
-		assertType('FlowdGmbh\\MyProject\\Http\\MyAttribute', $request->getAttribute('myCustomAttribute'));
-		assertType('FlowdGmbh\\MyProject\\Http\\MyAttribute|null', $request->getAttribute('myCustomNullableAttribute'));
+		assertType(SiteLanguage::class . '|null', $request->getAttribute('language'));
+		assertType(Site::class . '|null', $request->getAttribute('site'));
+		assertType(NormalizedParams::class . '|null', $request->getAttribute('normalizedParams'));
+		assertType('1|2|4|8|16|null', $request->getAttribute('applicationType'));
+		assertType('FlowdGmbh\\MyProject\\Http\\MyAttribute|null', $request->getAttribute('myCustomAttribute'));
+		assertType('FlowdGmbh\\MyProject\\Http\\MyAttribute|int|null', $request->getAttribute('myCustomThatCanBeIntAttribute'));
 	}
 
 }


### PR DESCRIPTION
The types defined in the `parameters.typo3.contextApiGetAspectMapping`
and `parameters.typo3.requestGetAttributeMapping` can now be more complex
phpDoc types. This is useful if e.g. a request argument can be nullable
or of diffent type.

Tests have been added to test the behavior.

Beside that a validation rule has been added that gives a hint
if a request attribute mapping for phpstan is missing.