### PR TITLE
[TASK] Make the test matrix entries explicit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,14 +11,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version:
-          - "7.3"
-          - "7.4"
-          - "8.0"
-          - "8.1"
-        composer-flags:
-          - ""
-          - " --prefer-lowest"
+        include:
+          - php-version: "7.3"
+            composer-flags: ""
+          - php-version: "7.3"
+            composer-flags: " --prefer-lowest"
+          - php-version: "7.4"
+            composer-flags: ""
+          - php-version: "7.4"
+            composer-flags: " --prefer-lowest"
+          - php-version: "8.0"
+            composer-flags: ""
+          - php-version: "8.0"
+            composer-flags: " --prefer-lowest"
+          - php-version: "8.1"
+            composer-flags: ""
+          - php-version: "8.1"
+            composer-flags: " --prefer-lowest"
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
This allows having only a subset of tests when new PHP versions and TYPO3 versions are added (where not all combinations are possible).