### PR TITLE
[TASK] Drop support for TYPO3 8LTS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         "php": "^7.2 || ^8.0",
         "phpstan/phpstan": "^1.8",
         "nikic/php-parser": ">= 4.13",
-        "typo3/cms-core": "^8.7 || ^9.5 || ^10.4 || ^11.2",
-        "typo3/cms-extbase": "^8.7 || ^9.5 || ^10.4 || ^11.2"
+        "typo3/cms-core": "^9.5 || ^10.4 || ^11.2",
+        "typo3/cms-extbase": "^9.5 || ^10.4 || ^11.2"
     },
     "require-dev": {
         "consistence-community/coding-standard": "^3.10",


### PR DESCRIPTION
TYPO3 8LTS has reached its end of life quite some time ago, and getting the tests to work (in order to ensure this package works fine with 8LTS) is quite some hassle.