### PR TITLE
[TASK] Downgrade to PHPUnit 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phing/phing": "^2.17",
         "phpstan/phpstan-strict-rules": "^1.0",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^8.5.30",
         "symfony/polyfill-php80": "^1.26.0"
     },
     "autoload": {


### PR DESCRIPTION
As long as this package supports PHP 7.2, it needs to use PHPUnit 8.5 in order to run the tests as PHPUnit 9.5 requires PHP >= 7.3.