### PR TITLE
[BUGFIX] Add `symfony/polyfill-php80` as a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phing/phing": "^2.17",
         "phpstan/phpstan-strict-rules": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "symfony/polyfill-php80": "^1.26.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Otherwise, a test with TYPO3 11LTS with the lowest dependencies will fail in PHP 7.4 due to a missing `str_starts_with` function.