### PR TITLE
[FEATURE] Add PHP 7.2 to the CI test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,12 @@ jobs:
       matrix:
         include:
           - typo3-version: "^9.5"
+            php-version: "7.2"
+            composer-flags: ""
+          - typo3-version: "^9.5"
+            php-version: "7.2"
+            composer-flags: " --prefer-lowest"
+          - typo3-version: "^9.5"
             php-version: "7.3"
             composer-flags: ""
           - typo3-version: "^9.5"


### PR DESCRIPTION
After the downgrade to PHPUnit 8.5, we now can run the tests on PHP 7.2 as well, ensuring that everything works fine.