### PR TITLE
[BUGFIX] Use a bounded dependency on `nikic/php-parser`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "phpstan/phpstan": "^1.8",
-        "nikic/php-parser": ">= 4.13",
+        "nikic/php-parser": "^4.13.0",
         "typo3/cms-core": "^9.5 || ^10.4 || ^11.5",
         "typo3/cms-extbase": "^9.5 || ^10.4 || ^11.5"
     },


### PR DESCRIPTION
This avoids pulling in a newer version of this package with breaking changes. (Currently, version with breaking changes is in development.)