### PR TITLE
[TASK] Sync the `.editorconfig` with the TYPO3 coding standards package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,27 +1,60 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
 root = true
 
+# Unix-style newlines with a newline ending every file
 [*]
-end_of_line = lf
-insert_final_newline = true
 charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{php,phpt}]
-indent_style = tab
-indent_size = 4
-
-[*.xml]
-indent_style = tab
-indent_size = 4
-
-[*.neon]
-indent_style = tab
-indent_size = 4
-
-[*.{yaml,yml}]
-indent_style = space
+# TS/JS-Files
+[*.{ts,js}]
 indent_size = 2
 
-[composer.json]
+# JSON-Files
+[*.json]
 indent_style = tab
+
+# ReST-Files
+[*.{rst,rst.txt}]
 indent_size = 4
+max_line_length = 80
+
+# Markdown-Files
+[*.md]
+max_line_length = 80
+
+# YAML-Files
+[*.{yaml,yml}]
+indent_size = 2
+
+# NEON-Files
+[*.neon]
+indent_size = 2
+indent_style = tab
+
+# package.json
+[package.json]
+indent_size = 2
+
+# TypoScript
+[*.{typoscript,tsconfig}]
+indent_size = 2
+
+# XLF-Files
+[*.xlf]
+indent_style = tab
+
+# SQL-Files
+[*.sql]
+indent_style = tab
+indent_size = 2
+
+# .htaccess
+[{_.htaccess,.htaccess}]
+indent_style = tab


### PR DESCRIPTION
This allows to keep things consistent with other TYPO3-related packages, and also covers some more file types.