### PR TITLE
[BUGFIX] Stop relying on transitive dependencies

### DIFF
--- a/src/Rule/RequestAttributeValidationRule.php
+++ b/src/Rule/RequestAttributeValidationRule.php
@@ -45,9 +45,11 @@ class RequestAttributeValidationRule implements \PHPStan\Rules\Rule
 
 		$declaringClass = $methodReflection->getDeclaringClass();
 
-		if (!$declaringClass->implementsInterface(ServerRequestInterface::class)
-			&& $declaringClass->getName() !== ServerRequestInterface::class) {
-			return [];
+		if (interface_exists(ServerRequestInterface::class)) {
+			if (!$declaringClass->implementsInterface(ServerRequestInterface::class)
+				&& $declaringClass->getName() !== ServerRequestInterface::class) {
+				return [];
+			}
 		}
 
 		$argument = $node->getArgs()[0] ?? null;

--- a/src/Type/RequestDynamicReturnTypeExtension.php
+++ b/src/Type/RequestDynamicReturnTypeExtension.php
@@ -10,6 +10,7 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use Psr\Http\Message\ServerRequestInterface;
 
 class RequestDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -31,7 +32,13 @@ class RequestDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtens
 
 	public function getClass(): string
 	{
-		return \Psr\Http\Message\ServerRequestInterface::class;
+		if (!interface_exists(ServerRequestInterface::class)) {
+			throw new \PHPStan\ShouldNotHappenException(
+				'The package "psr/http-message" is not installed, but should be.'
+			);
+		}
+
+		return ServerRequestInterface::class;
 	}
 
 	public function getTypeFromMethodCall(


### PR DESCRIPTION
If `psr/http-message` is not installed, we now fail hard with a helpful exception message.