### PR TITLE
[BUGFIX] QueryInterfaceDynamicReturnTypeExtension with TYPO3\CMS\Extb…

### DIFF
--- a/src/Type/QueryInterfaceDynamicReturnTypeExtension.php
+++ b/src/Type/QueryInterfaceDynamicReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace SaschaEgerer\PhpstanTypo3\Type;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
-use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
@@ -57,7 +56,7 @@ class QueryInterfaceDynamicReturnTypeExtension implements DynamicMethodReturnTyp
 				$modelName = $this->translateRepositoryNameToModelName(
 					$classReflection->getName()
 				);
-			} catch (ShouldNotHappenException $e) {
+			} catch (\PHPStan\ShouldNotHappenException $e) {
 				return new ErrorType();
 			}
 

--- a/src/Type/QueryInterfaceDynamicReturnTypeExtension.php
+++ b/src/Type/QueryInterfaceDynamicReturnTypeExtension.php
@@ -5,6 +5,7 @@ namespace SaschaEgerer\PhpstanTypo3\Type;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;

--- a/src/Type/QueryInterfaceDynamicReturnTypeExtension.php
+++ b/src/Type/QueryInterfaceDynamicReturnTypeExtension.php
@@ -38,7 +38,7 @@ class QueryInterfaceDynamicReturnTypeExtension implements DynamicMethodReturnTyp
 		MethodReflection $methodReflection,
 		MethodCall $methodCall,
 		Scope $scope
-	): Type
+	): ?Type
 	{
 		$argument = $methodCall->getArgs()[0] ?? null;
 
@@ -57,7 +57,7 @@ class QueryInterfaceDynamicReturnTypeExtension implements DynamicMethodReturnTyp
 					$classReflection->getName()
 				);
 			} catch (\PHPStan\ShouldNotHappenException $e) {
-				return new ErrorType();
+				return null;
 			}
 
 			$modelType = [new ObjectType($modelName)];

--- a/src/Type/QueryInterfaceDynamicReturnTypeExtension.php
+++ b/src/Type/QueryInterfaceDynamicReturnTypeExtension.php
@@ -52,9 +52,13 @@ class QueryInterfaceDynamicReturnTypeExtension implements DynamicMethodReturnTyp
 				return new ErrorType();
 			}
 
-			$modelName = $this->translateRepositoryNameToModelName(
-				$classReflection->getName()
-			);
+			try {
+				$modelName = $this->translateRepositoryNameToModelName(
+					$classReflection->getName()
+				);
+			} catch (ShouldNotHappenException $e) {
+				return new ErrorType();
+			}
 
 			$modelType = [new ObjectType($modelName)];
 		}


### PR DESCRIPTION
…ase\Persistence\Generic\Query

In combination with rector We get the error: Uncaught PHPStan\ShouldNotHappenException: Repository class "TYPO3\CMS\Extbase\Persistence\Generic\Query" must implement "TYPO3\CMS\Extbase\Persistence\RepositoryInterface" in /app/vendor/saschaegerer/phpstan-typo3/src/Helpers/Typo3ClassNamingUtilityTrait.php:24