### PR TITLE
[BUGFIX] Include default value passed to `$request->getAttribute()`

### DIFF
--- a/tests/Unit/Type/data/request-get-attribute-return-types.php
+++ b/tests/Unit/Type/data/request-get-attribute-return-types.php
@@ -4,6 +4,7 @@ namespace RequestGetAttributeReturnTypes;
 
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\NormalizedParams;
+use TYPO3\CMS\Core\Site\Entity\NullSite;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use function PHPStan\Testing\assertType;
@@ -21,6 +22,7 @@ class MyRequest
 		);
 		assertType(SiteLanguage::class . '|null', $request->getAttribute('language'));
 		assertType(Site::class . '|null', $request->getAttribute('site'));
+		assertType(NullSite::class . '|' . Site::class, $request->getAttribute('site', new NullSite()));
 		assertType(NormalizedParams::class . '|null', $request->getAttribute('normalizedParams'));
 		assertType('1|2|4|8|16|null', $request->getAttribute('applicationType'));
 		assertType('FlowdGmbh\\MyProject\\Http\\MyAttribute|null', $request->getAttribute('myCustomAttribute'));


### PR DESCRIPTION
Whenever the `$request->getAttribute()` method is called, it is possible to provide a default value in case the given argument resolves to `null`. Thus, the default value should be part of the return type.

Example:

```php
use TYPO3\CMS\Core\Site\Entity\NullSite;
use TYPO3\CMS\Core\Site\Entity\Site;

/** @var NullSite|Site $site */
$site = $request->getAttribute('site', new NullSite());
```