### PR TITLE
Load TYPO3 version specific stubs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
 		"nikic/php-parser": "^4.15.1",
 		"typo3/cms-core": "^10.4 || ^11.5 || ^12.2",
 		"typo3/cms-extbase": "^10.4 || ^11.5 || ^12.2",
-		"bnf/phpstan-psr-container": "^1.0"
+		"bnf/phpstan-psr-container": "^1.0",
+		"composer/semver": "^3.3"
 	},
 	"require-dev": {
 		"consistence-community/coding-standard": "^3.10.1",

--- a/extension.neon
+++ b/extension.neon
@@ -89,6 +89,10 @@ services:
         class: SaschaEgerer\PhpstanTypo3\Type\MathUtilityTypeSpecifyingExtension
         tags:
             - phpstan.typeSpecifier.staticMethodTypeSpecifyingExtension
+    -
+        class: SaschaEgerer\PhpstanTypo3\Stubs\StubFilesExtensionLoader
+        tags:
+            - phpstan.stubFilesExtension
 parameters:
     bootstrapFiles:
         - phpstan.bootstrap.php
@@ -121,13 +125,15 @@ parameters:
             websiteTitle: string
     stubFiles:
         - stubs/DomainObjectInterface.stub
-        - stubs/GeneralUtility.stub
         - stubs/ObjectStorage.stub
         - stubs/QueryFactory.stub
         - stubs/QueryInterface.stub
         - stubs/QueryResultInterface.stub
-        - stubs/QueryResult.stub
         - stubs/Repository.stub
+        # See SaschaEgerer\PhpstanTypo3\Stubs\StubFilesExtensionLoader
+        # GeneralUtility.stub is only used if TYPO3 version is < 12
+        #- stubs/GeneralUtility.stub
+        #- stubs/QueryResult.stub
     dynamicConstantNames:
         - TYPO3_MODE
         - TYPO3_REQUESTTYPE

--- a/src/Stubs/StubFilesExtensionLoader.php
+++ b/src/Stubs/StubFilesExtensionLoader.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace SaschaEgerer\PhpstanTypo3\Stubs;
+
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
+
+class StubFilesExtensionLoader implements \PHPStan\PhpDoc\StubFilesExtension
+{
+
+	public function getFiles(): array
+	{
+		$stubsDir = dirname(__DIR__, 2) . '/stubs';
+		$files = [];
+		if (InstalledVersions::satisfies(new VersionParser(), 'typo3/cms-core', '< 12')) {
+			$files[] = $stubsDir . '/GeneralUtility.stub';
+		}
+		if (InstalledVersions::satisfies(new VersionParser(), 'typo3/cms-core', '<= 12.2.0')) {
+			$files[] = $stubsDir . '/QueryResult.stub';
+		}
+
+		return $files;
+	}
+
+}

--- a/src/Stubs/StubFilesExtensionLoader.php
+++ b/src/Stubs/StubFilesExtensionLoader.php
@@ -2,8 +2,8 @@
 
 namespace SaschaEgerer\PhpstanTypo3\Stubs;
 
-use Composer\InstalledVersions;
 use Composer\Semver\VersionParser;
+use TYPO3\CMS\Core\Information\Typo3Version;
 
 class StubFilesExtensionLoader implements \PHPStan\PhpDoc\StubFilesExtension
 {
@@ -12,10 +12,13 @@ class StubFilesExtensionLoader implements \PHPStan\PhpDoc\StubFilesExtension
 	{
 		$stubsDir = dirname(__DIR__, 2) . '/stubs';
 		$files = [];
-		if (InstalledVersions::satisfies(new VersionParser(), 'typo3/cms-core', '< 12')) {
+		$typo3Version = new Typo3Version();
+		$versionParser = new VersionParser();
+
+		if ($versionParser->parseConstraints($typo3Version->getVersion())->matches($versionParser->parseConstraints('< 12'))) {
 			$files[] = $stubsDir . '/GeneralUtility.stub';
 		}
-		if (InstalledVersions::satisfies(new VersionParser(), 'typo3/cms-core', '<= 12.2.0')) {
+		if ($versionParser->parseConstraints($typo3Version->getVersion())->matches($versionParser->parseConstraints('<= 12.2.0'))) {
 			$files[] = $stubsDir . '/QueryResult.stub';
 		}
 


### PR DESCRIPTION
The TYPO3 core is going to fix and extend some
of its types and annocations. We have to react
at some places and must not load some stubs anymore in newer TYPO3 versions.

Issue: #114