### PR TITLE
[BUGFIX] Fix type annotation in the `GeneralUtility` stub

### DIFF
--- a/stubs/GeneralUtility.stub
+++ b/stubs/GeneralUtility.stub
@@ -6,7 +6,7 @@ class GeneralUtility
     /**
      * @template T of object
      * @phpstan-param class-string<T> $className
-     * @phpstan-param array<int, mixed> $constructorArguments
+     * @phpstan-param mixed $constructorArguments
      * @phpstan-return T
      */
     public static function makeInstance($className, ...$constructorArguments);


### PR DESCRIPTION
For variable arguments, the type annotation needs to match the type of the single arguments, not an array of the single arguments.

This change parallels that in the TYPO3 Core:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/78080