### PR TITLE
[TASK] Add currentContentObject to typo3.requestGetAttributeMapping

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -115,6 +115,7 @@ parameters:
             site: TYPO3\CMS\Core\Site\Entity\Site
             applicationType: TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_*
             routing: TYPO3\CMS\Core\Routing\SiteRouteResult|TYPO3\CMS\Core\Routing\PageArguments
+			currentContentObject: TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
         siteGetAttributeMapping:
             base: string
             baseVariants: list

--- a/extension.neon
+++ b/extension.neon
@@ -115,7 +115,7 @@ parameters:
             site: TYPO3\CMS\Core\Site\Entity\Site
             applicationType: TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_*
             routing: TYPO3\CMS\Core\Routing\SiteRouteResult|TYPO3\CMS\Core\Routing\PageArguments
-			currentContentObject: TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
+            currentContentObject: TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
         siteGetAttributeMapping:
             base: string
             baseVariants: list


### PR DESCRIPTION
The current content object is now available as request attribute - see https://forge.typo3.org/issues/100623

This change updates `typo3.requestGetAttributeMapping`, so `currentContentObject` can be resolved