### PR TITLE
[FEATURE] Add dynamic return type extension for UserAspect::get()

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -97,6 +97,10 @@ services:
         class: SaschaEgerer\PhpstanTypo3\Stubs\StubFilesExtensionLoader
         tags:
             - phpstan.stubFilesExtension
+    -
+        class: SaschaEgerer\PhpstanTypo3\Type\UserAspectGetDynamicReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
 parameters:
     bootstrapFiles:
         - phpstan.bootstrap.php

--- a/src/Type/UserAspectGetDynamicReturnTypeExtension.php
+++ b/src/Type/UserAspectGetDynamicReturnTypeExtension.php
@@ -43,14 +43,19 @@ class UserAspectGetDynamicReturnTypeExtension implements DynamicMethodReturnType
 		$argumentType = $scope->getType($firstArgument->value);
 
 		if ($argumentType instanceof ConstantStringType) {
-			return match ($argumentType->getValue()) {
-				'id' => IntegerRangeType::createAllGreaterThanOrEqualTo(0),
-				'username' => new StringType(),
-				'isLoggedIn', 'isAdmin' => new BooleanType(),
-				'groupIds' => new ArrayType(new IntegerType(), IntegerRangeType::fromInterval(-2, null)),
-				'groupNames' => new ArrayType(new IntegerType(), new StringType()),
-				default => null,
-			};
+			switch ($argumentType->getValue()) {
+				case 'id':
+					return IntegerRangeType::createAllGreaterThanOrEqualTo(0);
+				case 'username':
+					return new StringType();
+				case 'isLoggedIn':
+				case 'isAdmin':
+					return new BooleanType();
+				case 'groupIds':
+					return new ArrayType(new IntegerType(), IntegerRangeType::fromInterval(-2, null));
+				case 'groupNames':
+					return new ArrayType(new IntegerType(), new StringType());
+			}
 		}
 
 		return null;

--- a/src/Type/UserAspectGetDynamicReturnTypeExtension.php
+++ b/src/Type/UserAspectGetDynamicReturnTypeExtension.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types = 1);
+
+namespace SaschaEgerer\PhpstanTypo3\Type;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\StringType;
+use TYPO3\CMS\Core\Context\UserAspect;
+
+class UserAspectGetDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return UserAspect::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'get';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): ?\PHPStan\Type\Type
+	{
+		$firstArgument = $methodCall->args[0];
+
+		if (!$firstArgument instanceof Arg) {
+			return null;
+		}
+
+		$argumentType = $scope->getType($firstArgument->value);
+
+		if ($argumentType instanceof ConstantStringType) {
+			return match ($argumentType->getValue()) {
+				'id' => IntegerRangeType::createAllGreaterThanOrEqualTo(0),
+				'username' => new StringType(),
+				'isLoggedIn', 'isAdmin' => new BooleanType(),
+				'groupIds' => new ArrayType(new IntegerType(), IntegerRangeType::fromInterval(-2, null)),
+				'groupNames' => new ArrayType(new IntegerType(), new StringType()),
+				default => null,
+			};
+		}
+
+		return null;
+	}
+
+}

--- a/tests/Unit/Type/UserAspectGetDynamicReturnTypeExtension/UserAspectGetDynamicReturnTypeExtensionTest.php
+++ b/tests/Unit/Type/UserAspectGetDynamicReturnTypeExtension/UserAspectGetDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace SaschaEgerer\PhpstanTypo3\Tests\Unit\Type\UserAspectGetDynamicReturnTypeExtension;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+final class UserAspectGetDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+
+	/**
+	 *
+	 * @return iterable<mixed>
+	 */
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/user-aspect-get-return-types.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param string $assertType
+	 * @param string $file
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../../../extension.neon',
+		];
+	}
+
+}

--- a/tests/Unit/Type/UserAspectGetDynamicReturnTypeExtension/data/user-aspect-get-return-types.php
+++ b/tests/Unit/Type/UserAspectGetDynamicReturnTypeExtension/data/user-aspect-get-return-types.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace SaschaEgerer\PhpstanTypo3\Tests\Unit\Type\UserAspectGetDynamicReturnTypeExtension\data;
+
+use TYPO3\CMS\Core\Context\UserAspect;
+
+use function PHPStan\Testing\assertType;
+
+// phpcs:ignore Squiz.Classes.ClassFileName.NoMatch
+class MyContext
+{
+
+	public function getTests(UserAspect $context): void
+	{
+		assertType('int<0, max>', $context->get('id'));
+		assertType('string', $context->get('username'));
+		assertType('bool', $context->get('isLoggedIn'));
+		assertType('bool', $context->get('isAdmin'));
+		assertType('array<int, int<-2, max>>', $context->get('groupIds'));
+		assertType('array<int, string>', $context->get('groupNames'));
+	}
+
+}


### PR DESCRIPTION
Hi,
this is a dynamic return type extension for `UserAspect::get()`. There are dedicated getters but since `get()` exists and is in use, I'd like to have phpstan type support here.

Thanks for having a look.
Cheers. :)