### PR TITLE
Deactivate stubs depending on TYPO3 version

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -139,12 +139,6 @@ parameters:
             routeEnhancers: array
             websiteTitle: string
     stubFiles:
-        - stubs/DomainObjectInterface.stub
-        - stubs/ObjectStorage.stub
-        - stubs/QueryFactory.stub
-        - stubs/QueryInterface.stub
-        - stubs/QueryResultInterface.stub
-        - stubs/Repository.stub
         # See SaschaEgerer\PhpstanTypo3\Stubs\StubFilesExtensionLoader
         # GeneralUtility.stub is only used if TYPO3 version is < 12
         #- stubs/GeneralUtility.stub

--- a/src/Stubs/StubFilesExtensionLoader.php
+++ b/src/Stubs/StubFilesExtensionLoader.php
@@ -15,11 +15,21 @@ class StubFilesExtensionLoader implements \PHPStan\PhpDoc\StubFilesExtension
 		$typo3Version = new Typo3Version();
 		$versionParser = new VersionParser();
 
+		if ($versionParser->parseConstraints($typo3Version->getVersion())->matches($versionParser->parseConstraints('<= 11.3.0'))) {
+			$files[] = $stubsDir . '/ObjectStorage.stub';
+		}
+
 		if ($versionParser->parseConstraints($typo3Version->getVersion())->matches($versionParser->parseConstraints('< 12'))) {
 			$files[] = $stubsDir . '/GeneralUtility.stub';
 		}
+
 		if ($versionParser->parseConstraints($typo3Version->getVersion())->matches($versionParser->parseConstraints('<= 12.2.0'))) {
+			$files[] = $stubsDir . '/DomainObjectInterface.stub';
+			$files[] = $stubsDir . '/QueryFactory.stub';
+			$files[] = $stubsDir . '/QueryInterface.stub';
 			$files[] = $stubsDir . '/QueryResult.stub';
+			$files[] = $stubsDir . '/QueryResultInterface.stub';
+			$files[] = $stubsDir . '/Repository.stub';
 		}
 
 		return $files;


### PR DESCRIPTION
Hi,

looking at TYPO3 12.4, all stubs are rather outdated. Their purpose was to teach phpstan extbase generics but this is now fully covered by the core.

I know the tests do fail now but I am not 100% sure why. I guess it's because they rely on the stubs that are now loaded dynamically but I don't know how to adjust the tests accordingly. Maybe anyone with insights can help?

Thnaks in advance.

Relates: #133