### PR TITLE
[BUGFIX] Do not try to find model for abstract repository

### DIFF
--- a/src/Reflection/RepositoryCountByMethodsClassReflectionExtension.php
+++ b/src/Reflection/RepositoryCountByMethodsClassReflectionExtension.php
@@ -32,6 +32,10 @@ class RepositoryCountByMethodsClassReflectionExtension implements MethodsClassRe
 			return false;
 		}
 
+		if ($classReflection->isAbstract()) {
+			return false;
+		}
+
 		if (strpos($methodName, 'countBy') !== 0) {
 			return false;
 		}

--- a/src/Reflection/RepositoryFindMethodsClassReflectionExtension.php
+++ b/src/Reflection/RepositoryFindMethodsClassReflectionExtension.php
@@ -34,6 +34,10 @@ class RepositoryFindMethodsClassReflectionExtension implements MethodsClassRefle
 			return false;
 		}
 
+		if ($classReflection->isAbstract()) {
+			return false;
+		}
+
 		if (strpos($methodName, 'findOneBy') === 0) {
 			$propertyName = lcfirst(substr($methodName, 9));
 		} elseif (strpos($methodName, 'findBy') === 0) {

--- a/tests/Unit/Type/data/repository-stub-files.php
+++ b/tests/Unit/Type/data/repository-stub-files.php
@@ -14,6 +14,14 @@ class MyModel extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
 
 }
 
+class ExtendingMyAbstractModel extends  \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
+{
+
+	/** @var string */
+	protected $foo;
+
+}
+
 namespace RepositoryStubFiles\My\Test\Extension\Domain\Repository;
 
 use function PHPStan\Testing\assertType;
@@ -55,9 +63,42 @@ class MyModelRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 			'int',
 			$this->countByFoo('a')
 		);
+
+		// call findBy with non-existing model property
+		assertType(
+			'*ERROR*',
+			$this->findByNonexisting('a')
+		);
 	}
 
 }
+
+/** @extends \TYPO3\CMS\Extbase\Persistence\Repository<\TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface> */
+abstract class MyAbstractModelRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
+{
+
+}
+
+/** @template TEntityClass of \RepositoryStubFiles\My\Test\Extension\Domain\Model\ExtendingMyAbstractModel **/
+class ExtendingMyAbstractModelRepository extends MyAbstractModelRepository
+{
+
+	public function myTests(): void
+	{
+		// call findBy with a non existing model property
+		assertType(
+			'TYPO3\CMS\Extbase\Persistence\QueryResultInterface<RepositoryStubFiles\My\Test\Extension\Domain\Model\ExtendingMyAbstractModel>',
+			$this->findByFoo('a')
+		);
+		// call findBy with a non existing model property
+		assertType(
+			'*ERROR*',
+			$this->findByNonexisting('a')
+		);
+	}
+
+}
+
 
 class MyModelWithoutExtends extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
 {

--- a/tests/Unit/Type/data/repository-stub-files.php
+++ b/tests/Unit/Type/data/repository-stub-files.php
@@ -69,6 +69,10 @@ class MyModelRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 			'*ERROR*',
 			$this->findByNonexisting('a')
 		);
+		assertType(
+			'*ERROR*',
+			$this->countByNonexisting('a')
+		);
 	}
 
 }
@@ -94,6 +98,10 @@ class ExtendingMyAbstractModelRepository extends MyAbstractModelRepository
 		assertType(
 			'*ERROR*',
 			$this->findByNonexisting('a')
+		);
+		assertType(
+			'*ERROR*',
+			$this->countByNonexisting('a')
 		);
 	}
 


### PR DESCRIPTION
If a repository is abstract we must not try to find a model based on the repository name.

Resolves: #140