### PR TITLE
[TASK] Bump the production dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
 	"prefer-stable": true,
 	"require": {
 		"php": "^7.4 || ^8.0",
-		"phpstan/phpstan": "^1.8.9",
-		"nikic/php-parser": "^4.15.1",
+		"phpstan/phpstan": "^1.10.27",
+		"nikic/php-parser": "^4.18.0",
 		"typo3/cms-core": "^10.4 || ^11.5 || ^12.4 || ^13.0",
 		"typo3/cms-extbase": "^10.4 || ^11.5 || ^12.4 || ^13.0",
-		"bnf/phpstan-psr-container": "^1.0",
-		"composer/semver": "^3.3"
+		"bnf/phpstan-psr-container": "^1.0.1",
+		"composer/semver": "^3.4.0"
 	},
 	"require-dev": {
 		"consistence-community/coding-standard": "^3.11.1",


### PR DESCRIPTION
The required PHPStan version is lower than the currently latest version
in order to allow installations together with the latest release of
`ssch/typo3-rector` (which has a hard dependency on `rector/rector:0.17.0`,
which in turn requires `phpstan/phpstan:^1.10.15`).