### PR TITLE
[TASK] Bump PHPStan to ^1.10.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"prefer-stable": true,
 	"require": {
 		"php": "^7.4 || ^8.0",
-		"phpstan/phpstan": "^1.8.9",
+		"phpstan/phpstan": "^1.10.9",
 		"nikic/php-parser": "^4.15.1",
 		"typo3/cms-core": "^10.4 || ^11.5 || ^12.4 || ^13.0",
 		"typo3/cms-extbase": "^10.4 || ^11.5 || ^12.4 || ^13.0",


### PR DESCRIPTION
This version of PHPStan makes some test-related methods static, which is required for newer PHPUnit versions (where data providers are required to be static).