### PR TITLE
[!!!][TASK] Drop support for TYPO3 10LTS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: "^10.4"
-            php-version: "7.4"
-            composer-flags: ""
-          - typo3-version: "^10.4"
-            php-version: "7.4"
-            composer-flags: " --prefer-lowest"
           - typo3-version: "^11.5"
             php-version: "7.4"
             composer-flags: ""

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
 		"php": "^7.4 || ^8.0",
 		"phpstan/phpstan": "^1.10.9",
 		"nikic/php-parser": "^4.15.1",
-		"typo3/cms-core": "^10.4 || ^11.5 || ^12.4 || ^13.0",
-		"typo3/cms-extbase": "^10.4 || ^11.5 || ^12.4 || ^13.0",
+		"typo3/cms-core": "^11.5 || ^12.4 || ^13.0",
+		"typo3/cms-extbase": "^11.5 || ^12.4 || ^13.0",
 		"bnf/phpstan-psr-container": "^1.0",
 		"composer/semver": "^3.3"
 	},


### PR DESCRIPTION
With the PHP version requirement being >= 7.4, usage of this package for extensions that still support TYPO3 10LTS (and hence usually also support TYPO3 7.2 and 7.3) was limited anyway.