### PR TITLE
[TASK] Use Type declarations and remove redundant docblocks

### DIFF
--- a/src/Reflection/RepositoryCountByMethodReflection.php
+++ b/src/Reflection/RepositoryCountByMethodReflection.php
@@ -6,6 +6,7 @@ use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionVariant;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\IntegerType;
@@ -15,11 +16,9 @@ use PHPStan\Type\Type;
 class RepositoryCountByMethodReflection implements MethodReflection
 {
 
-	/** @var \PHPStan\Reflection\ClassReflection */
-	private $classReflection;
+	private ClassReflection $classReflection;
 
-	/** @var string */
-	private $name;
+	private string $name;
 
 	public function __construct(ClassReflection $classReflection, string $name)
 	{
@@ -76,7 +75,7 @@ class RepositoryCountByMethodReflection implements MethodReflection
 	}
 
 	/**
-	 * @return \PHPStan\Reflection\ParametersAcceptor[]
+	 * @return ParametersAcceptor[]
 	 */
 	public function getVariants(): array
 	{
@@ -96,7 +95,7 @@ class RepositoryCountByMethodReflection implements MethodReflection
 		return null;
 	}
 
-	public function isDeprecated(): \PHPStan\TrinaryLogic
+	public function isDeprecated(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
 	}
@@ -106,22 +105,22 @@ class RepositoryCountByMethodReflection implements MethodReflection
 		return null;
 	}
 
-	public function isFinal(): \PHPStan\TrinaryLogic
+	public function isFinal(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
 	}
 
-	public function isInternal(): \PHPStan\TrinaryLogic
+	public function isInternal(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
 	}
 
-	public function getThrowType(): ?\PHPStan\Type\Type
+	public function getThrowType(): ?Type
 	{
 		return null;
 	}
 
-	public function hasSideEffects(): \PHPStan\TrinaryLogic
+	public function hasSideEffects(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
 	}

--- a/src/Reflection/RepositoryCountByMethodsClassReflectionExtension.php
+++ b/src/Reflection/RepositoryCountByMethodsClassReflectionExtension.php
@@ -14,8 +14,7 @@ class RepositoryCountByMethodsClassReflectionExtension implements MethodsClassRe
 
 	use Typo3ClassNamingUtilityTrait;
 
-	/** @var ReflectionProvider */
-	private $reflectionProvider;
+	private ReflectionProvider $reflectionProvider;
 
 	public function __construct(ReflectionProvider $reflectionProvider)
 	{

--- a/src/Reflection/RepositoryCountByParameterReflection.php
+++ b/src/Reflection/RepositoryCountByParameterReflection.php
@@ -9,11 +9,9 @@ use PHPStan\Type\Type;
 class RepositoryCountByParameterReflection implements ParameterReflection
 {
 
-	/** @var string */
-	private $name;
+	private string $name;
 
-	/** @var Type */
-	private $type;
+	private Type $type;
 
 	public function __construct(string $name, Type $type)
 	{

--- a/src/Reflection/RepositoryFindByMethodReflection.php
+++ b/src/Reflection/RepositoryFindByMethodReflection.php
@@ -6,11 +6,14 @@ use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionVariant;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
 use SaschaEgerer\PhpstanTypo3\Helpers\Typo3ClassNamingUtilityTrait;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
@@ -19,14 +22,11 @@ class RepositoryFindByMethodReflection implements MethodReflection
 
 	use Typo3ClassNamingUtilityTrait;
 
-	/** @var \PHPStan\Reflection\ClassReflection */
-	private $classReflection;
+	private ClassReflection $classReflection;
 
-	/** @var string */
-	private $name;
+	private string $name;
 
-	/** @var ReflectionProvider */
-	private $reflectionProvider;
+	private ReflectionProvider $reflectionProvider;
 
 	public function __construct(ClassReflection $classReflection, string $name, ReflectionProvider $reflectionProvider)
 	{
@@ -89,7 +89,7 @@ class RepositoryFindByMethodReflection implements MethodReflection
 		if ($modelReflection->hasNativeProperty($this->getPropertyName())) {
 			$type = $modelReflection->getNativeProperty($this->getPropertyName())->getReadableType();
 		} else {
-			$type = new \PHPStan\Type\MixedType(\false);
+			$type = new MixedType(\false);
 		}
 
 		return [
@@ -108,7 +108,7 @@ class RepositoryFindByMethodReflection implements MethodReflection
 	}
 
 	/**
-	 * @return \PHPStan\Reflection\ParametersAcceptor[]
+	 * @return ParametersAcceptor[]
 	 */
 	public function getVariants(): array
 	{
@@ -148,7 +148,7 @@ class RepositoryFindByMethodReflection implements MethodReflection
 		return TrinaryLogic::createNo();
 	}
 
-	public function getThrowType(): ?\PHPStan\Type\Type
+	public function getThrowType(): ?Type
 	{
 		return null;
 	}

--- a/src/Reflection/RepositoryFindByParameterReflection.php
+++ b/src/Reflection/RepositoryFindByParameterReflection.php
@@ -11,11 +11,9 @@ use PHPStan\Type\TypeCombinator;
 class RepositoryFindByParameterReflection implements ParameterReflection
 {
 
-	/** @var string */
-	private $name;
+	private string $name;
 
-	/** @var Type */
-	private $type;
+	private Type $type;
 
 	public function __construct(string $name, Type $type)
 	{

--- a/src/Reflection/RepositoryFindMethodsClassReflectionExtension.php
+++ b/src/Reflection/RepositoryFindMethodsClassReflectionExtension.php
@@ -14,8 +14,7 @@ class RepositoryFindMethodsClassReflectionExtension implements MethodsClassRefle
 
 	use Typo3ClassNamingUtilityTrait;
 
-	/** @var ReflectionProvider $reflectionProvider */
-	private $reflectionProvider;
+	private ReflectionProvider $reflectionProvider;
 
 	public function __construct(
 		ReflectionProvider $reflectionProvider

--- a/src/Reflection/RepositoryFindOneByMethodReflection.php
+++ b/src/Reflection/RepositoryFindOneByMethodReflection.php
@@ -6,6 +6,7 @@ use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionVariant;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Generic\TemplateTypeMap;
@@ -19,14 +20,11 @@ class RepositoryFindOneByMethodReflection implements MethodReflection
 
 	use Typo3ClassNamingUtilityTrait;
 
-	/** @var \PHPStan\Reflection\ClassReflection */
-	private $classReflection;
+	private ClassReflection $classReflection;
 
-	/** @var string */
-	private $name;
+	private string $name;
 
-	/** @var ReflectionProvider */
-	private $reflectionProvider;
+	private ReflectionProvider $reflectionProvider;
 
 	public function __construct(ClassReflection $classReflection, string $name, ReflectionProvider $reflectionProvider)
 	{
@@ -105,7 +103,7 @@ class RepositoryFindOneByMethodReflection implements MethodReflection
 	}
 
 	/**
-	 * @return \PHPStan\Reflection\ParametersAcceptor[]
+	 * @return ParametersAcceptor[]
 	 */
 	public function getVariants(): array
 	{
@@ -125,7 +123,7 @@ class RepositoryFindOneByMethodReflection implements MethodReflection
 		return null;
 	}
 
-	public function isDeprecated(): \PHPStan\TrinaryLogic
+	public function isDeprecated(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
 	}
@@ -135,22 +133,22 @@ class RepositoryFindOneByMethodReflection implements MethodReflection
 		return null;
 	}
 
-	public function isFinal(): \PHPStan\TrinaryLogic
+	public function isFinal(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
 	}
 
-	public function isInternal(): \PHPStan\TrinaryLogic
+	public function isInternal(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
 	}
 
-	public function getThrowType(): ?\PHPStan\Type\Type
+	public function getThrowType(): ?Type
 	{
 		return null;
 	}
 
-	public function hasSideEffects(): \PHPStan\TrinaryLogic
+	public function hasSideEffects(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
 	}

--- a/src/Rule/ContextAspectValidationRule.php
+++ b/src/Rule/ContextAspectValidationRule.php
@@ -3,17 +3,23 @@
 namespace SaschaEgerer\PhpstanTypo3\Rule;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use TYPO3\CMS\Core\Context\Context;
 
 /**
- * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\MethodCall>
+ * @implements Rule<MethodCall>
  */
-class ContextAspectValidationRule implements \PHPStan\Rules\Rule
+class ContextAspectValidationRule implements Rule
 {
 
 	/** @var array<string, string> */
-	private $contextApiGetAspectMapping;
+	private array $contextApiGetAspectMapping;
 
 	/**
 	 * @param array<string, string> $contextApiGetAspectMapping
@@ -25,7 +31,7 @@ class ContextAspectValidationRule implements \PHPStan\Rules\Rule
 
 	public function getNodeType(): string
 	{
-		return Node\Expr\MethodCall::class;
+		return MethodCall::class;
 	}
 
 	/**
@@ -33,7 +39,7 @@ class ContextAspectValidationRule implements \PHPStan\Rules\Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!$node->name instanceof Node\Identifier) {
+		if (!$node->name instanceof Identifier) {
 			return [];
 		}
 
@@ -49,13 +55,13 @@ class ContextAspectValidationRule implements \PHPStan\Rules\Rule
 
 		$declaringClass = $methodReflection->getDeclaringClass();
 
-		if ($declaringClass->getName() !== \TYPO3\CMS\Core\Context\Context::class) {
+		if ($declaringClass->getName() !== Context::class) {
 			return [];
 		}
 
 		$argument = $node->getArgs()[0] ?? null;
 
-		if (!($argument instanceof Node\Arg) || !($argument->value instanceof Node\Scalar\String_)) {
+		if (!($argument instanceof Arg) || !($argument->value instanceof String_)) {
 			return [];
 		}
 

--- a/src/Rule/RequestAttributeValidationRule.php
+++ b/src/Rule/RequestAttributeValidationRule.php
@@ -3,18 +3,23 @@
 namespace SaschaEgerer\PhpstanTypo3\Rule;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\MethodCall>
+ * @implements Rule<MethodCall>
  */
-class RequestAttributeValidationRule implements \PHPStan\Rules\Rule
+class RequestAttributeValidationRule implements Rule
 {
 
 	/** @var array<string, string> */
-	private $requestGetAttributeMapping;
+	private array $requestGetAttributeMapping;
 
 	/**
 	 * @param array<string, string> $requestGetAttributeMapping
@@ -26,7 +31,7 @@ class RequestAttributeValidationRule implements \PHPStan\Rules\Rule
 
 	public function getNodeType(): string
 	{
-		return Node\Expr\MethodCall::class;
+		return MethodCall::class;
 	}
 
 	/**
@@ -34,7 +39,7 @@ class RequestAttributeValidationRule implements \PHPStan\Rules\Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!$node->name instanceof Node\Identifier) {
+		if (!$node->name instanceof Identifier) {
 			return [];
 		}
 
@@ -54,7 +59,7 @@ class RequestAttributeValidationRule implements \PHPStan\Rules\Rule
 
 		$argument = $node->getArgs()[0] ?? null;
 
-		if (!($argument instanceof Node\Arg) || !($argument->value instanceof Node\Scalar\String_)) {
+		if (!($argument instanceof Arg) || !($argument->value instanceof String_)) {
 			return [];
 		}
 

--- a/src/Rule/SiteAttributeValidationRule.php
+++ b/src/Rule/SiteAttributeValidationRule.php
@@ -3,18 +3,23 @@
 namespace SaschaEgerer\PhpstanTypo3\Rule;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use TYPO3\CMS\Core\Site\Entity\Site;
 
 /**
- * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\MethodCall>
+ * @implements Rule<MethodCall>
  */
-class SiteAttributeValidationRule implements \PHPStan\Rules\Rule
+class SiteAttributeValidationRule implements Rule
 {
 
 	/** @var array<string, string> */
-	private $siteGetAttributeMapping;
+	private array $siteGetAttributeMapping;
 
 	/**
 	 * @param array<string, string> $siteGetAttributeMapping
@@ -26,7 +31,7 @@ class SiteAttributeValidationRule implements \PHPStan\Rules\Rule
 
 	public function getNodeType(): string
 	{
-		return Node\Expr\MethodCall::class;
+		return MethodCall::class;
 	}
 
 	/**
@@ -34,7 +39,7 @@ class SiteAttributeValidationRule implements \PHPStan\Rules\Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!$node->name instanceof Node\Identifier) {
+		if (!$node->name instanceof Identifier) {
 			return [];
 		}
 
@@ -51,7 +56,7 @@ class SiteAttributeValidationRule implements \PHPStan\Rules\Rule
 
 		$argument = $node->getArgs()[0] ?? null;
 
-		if (!($argument instanceof Node\Arg) || !($argument->value instanceof Node\Scalar\String_)) {
+		if (!($argument instanceof Arg) || !($argument->value instanceof String_)) {
 			return [];
 		}
 

--- a/src/Rule/ValidatorResolverOptionsRule.php
+++ b/src/Rule/ValidatorResolverOptionsRule.php
@@ -4,10 +4,12 @@ namespace SaschaEgerer\PhpstanTypo3\Rule;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\InitializerExprTypeResolver;
@@ -31,11 +33,9 @@ use TYPO3\CMS\Extbase\Validation\ValidatorResolver;
 final class ValidatorResolverOptionsRule implements Rule
 {
 
-	/** @var InitializerExprTypeResolver */
-	private $initializerExprTypeResolver;
+	private InitializerExprTypeResolver $initializerExprTypeResolver;
 
-	/** @var ValidatorClassNameResolver */
-	private $validatorClassNameResolver;
+	private ValidatorClassNameResolver $validatorClassNameResolver;
 
 	public function __construct(
 		InitializerExprTypeResolver $initializerExprTypeResolver,
@@ -138,7 +138,7 @@ final class ValidatorResolverOptionsRule implements Rule
 			return true;
 		}
 
-		if (!$methodCall->name instanceof Node\Identifier) {
+		if (!$methodCall->name instanceof Identifier) {
 			return true;
 		}
 
@@ -246,12 +246,12 @@ final class ValidatorResolverOptionsRule implements Rule
 			return null;
 		}
 
-		if ($defaultValue->key instanceof ClassConstFetch && $defaultValue->key->name instanceof Node\Identifier) {
+		if ($defaultValue->key instanceof ClassConstFetch && $defaultValue->key->name instanceof Identifier) {
 			$keyType = $this->initializerExprTypeResolver->getClassConstFetchType(
 				$defaultValue->key->class,
 				$defaultValue->key->name->toString(),
 				$supportedOptions->getDeclaringClass()->getName(),
-				static function (\PhpParser\Node\Expr $expr) use ($scope): Type {
+				static function (Expr $expr) use ($scope): Type {
 					return $scope->getType($expr);
 				}
 			);

--- a/src/Rule/ValueObject/ValidatorOptionsConfiguration.php
+++ b/src/Rule/ValueObject/ValidatorOptionsConfiguration.php
@@ -6,10 +6,10 @@ final class ValidatorOptionsConfiguration
 {
 
 	/** @var string[] */
-	private $supportedOptions;
+	private array $supportedOptions;
 
 	/** @var string[] */
-	private $requriedOptions;
+	private array $requriedOptions;
 
 	/**
 	 * @param string[] $supportedOptions

--- a/src/Stubs/StubFilesExtensionLoader.php
+++ b/src/Stubs/StubFilesExtensionLoader.php
@@ -3,9 +3,10 @@
 namespace SaschaEgerer\PhpstanTypo3\Stubs;
 
 use Composer\Semver\VersionParser;
+use PHPStan\PhpDoc\StubFilesExtension;
 use TYPO3\CMS\Core\Information\Typo3Version;
 
-class StubFilesExtensionLoader implements \PHPStan\PhpDoc\StubFilesExtension
+class StubFilesExtensionLoader implements StubFilesExtension
 {
 
 	public function getFiles(): array

--- a/src/Type/ContextDynamicReturnTypeExtension.php
+++ b/src/Type/ContextDynamicReturnTypeExtension.php
@@ -3,21 +3,22 @@
 namespace SaschaEgerer\PhpstanTypo3\Type;
 
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Type;
+use TYPO3\CMS\Core\Context\Context;
 
 class ContextDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
 
 	/** @var array<string, string> */
-	private $contextApiGetAspectMapping;
+	private array $contextApiGetAspectMapping;
 
-	/** @var TypeStringResolver */
-	private $typeStringResolver;
+	private TypeStringResolver $typeStringResolver;
 
 	/**
 	 * @param array<string, string> $contextApiGetAspectMapping
@@ -30,7 +31,7 @@ class ContextDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtens
 
 	public function getClass(): string
 	{
-		return \TYPO3\CMS\Core\Context\Context::class;
+		return Context::class;
 	}
 
 	public function isMethodSupported(
@@ -48,7 +49,7 @@ class ContextDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtens
 	{
 		$argument = $methodCall->getArgs()[0] ?? null;
 
-		if ($argument === null || !($argument->value instanceof \PhpParser\Node\Scalar\String_)) {
+		if ($argument === null || !($argument->value instanceof String_)) {
 			return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 		}
 

--- a/src/Type/DateTimeAspectGetDynamicReturnTypeExtension.php
+++ b/src/Type/DateTimeAspectGetDynamicReturnTypeExtension.php
@@ -2,6 +2,7 @@
 
 namespace SaschaEgerer\PhpstanTypo3\Type;
 
+use DateTimeImmutable;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
@@ -11,6 +12,7 @@ use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
 use TYPO3\CMS\Core\Context\DateTimeAspect;
 
 class DateTimeAspectGetDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
@@ -30,7 +32,7 @@ class DateTimeAspectGetDynamicReturnTypeExtension implements DynamicMethodReturn
 		MethodReflection $methodReflection,
 		MethodCall $methodCall,
 		Scope $scope
-	): ?\PHPStan\Type\Type
+	): ?Type
 	{
 		$firstArgument = $methodCall->args[0];
 
@@ -49,7 +51,7 @@ class DateTimeAspectGetDynamicReturnTypeExtension implements DynamicMethodReturn
 				case 'timezone':
 					return new StringType();
 				case 'full':
-					return new ObjectType(\DateTimeImmutable::class);
+					return new ObjectType(DateTimeImmutable::class);
 			}
 		}
 

--- a/src/Type/GeneralUtilityGetIndpEnvDynamicReturnTypeExtension.php
+++ b/src/Type/GeneralUtilityGetIndpEnvDynamicReturnTypeExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
 use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -27,7 +28,7 @@ class GeneralUtilityGetIndpEnvDynamicReturnTypeExtension implements DynamicStati
 		return $methodReflection->getName() === 'getIndpEnv';
 	}
 
-	public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?\PHPStan\Type\Type
+	public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
 	{
 		$firstArgument = $methodCall->args[0];
 

--- a/src/Type/ObjectManagerDynamicReturnTypeExtension.php
+++ b/src/Type/ObjectManagerDynamicReturnTypeExtension.php
@@ -2,6 +2,7 @@
 
 namespace SaschaEgerer\PhpstanTypo3\Type;
 
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
@@ -10,6 +11,7 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 
 /**
  * @deprecated This class will be dropped once support for TYPO3 <= 10 is dropped.
@@ -19,15 +21,15 @@ class ObjectManagerDynamicReturnTypeExtension implements DynamicMethodReturnType
 
 	public function getClass(): string
 	{
-		return interface_exists(\TYPO3\CMS\Extbase\Object\ObjectManagerInterface::class)
-			? \TYPO3\CMS\Extbase\Object\ObjectManagerInterface::class : '';
+		return interface_exists(ObjectManagerInterface::class)
+			? ObjectManagerInterface::class : '';
 	}
 
 	public function isMethodSupported(
 		MethodReflection $methodReflection
 	): bool
 	{
-		return interface_exists(\TYPO3\CMS\Extbase\Object\ObjectManagerInterface::class)
+		return interface_exists(ObjectManagerInterface::class)
 			&& $methodReflection->getName() === 'get';
 	}
 
@@ -45,7 +47,7 @@ class ObjectManagerDynamicReturnTypeExtension implements DynamicMethodReturnType
 
 		$argumentValue = $argument->value;
 
-		if (!($argumentValue instanceof \PhpParser\Node\Expr\ClassConstFetch)) {
+		if (!($argumentValue instanceof ClassConstFetch)) {
 			return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 		}
 		/** @var Name $class */

--- a/src/Type/PropertyMapperReturnTypeExtension.php
+++ b/src/Type/PropertyMapperReturnTypeExtension.php
@@ -23,8 +23,7 @@ use TYPO3\CMS\Extbase\Property\PropertyMapper;
 final class PropertyMapperReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
 
-	/** @var ReflectionProvider */
-	private $reflectionProvider;
+	private ReflectionProvider $reflectionProvider;
 
 	public function __construct(ReflectionProvider $reflectionProvider)
 	{

--- a/src/Type/RepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/RepositoryDynamicReturnTypeExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use SaschaEgerer\PhpstanTypo3\Helpers\Typo3ClassNamingUtilityTrait;
+use TYPO3\CMS\Extbase\Persistence\RepositoryInterface;
 
 class RepositoryDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -19,7 +20,7 @@ class RepositoryDynamicReturnTypeExtension implements DynamicMethodReturnTypeExt
 
 	public function getClass(): string
 	{
-		return \TYPO3\CMS\Extbase\Persistence\RepositoryInterface::class;
+		return RepositoryInterface::class;
 	}
 
 	public function isMethodSupported(

--- a/src/Type/RepositoryFindAllDynamicReturnTypeExtension.php
+++ b/src/Type/RepositoryFindAllDynamicReturnTypeExtension.php
@@ -19,6 +19,7 @@ use SaschaEgerer\PhpstanTypo3\Helpers\Typo3ClassNamingUtilityTrait;
 use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
+use TYPO3\CMS\Extbase\Persistence\RepositoryInterface;
 
 class RepositoryFindAllDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -27,7 +28,7 @@ class RepositoryFindAllDynamicReturnTypeExtension implements DynamicMethodReturn
 
 	public function getClass(): string
 	{
-		return \TYPO3\CMS\Extbase\Persistence\RepositoryInterface::class;
+		return RepositoryInterface::class;
 	}
 
 	public function isMethodSupported(

--- a/src/Type/RepositoryQueryDynamicReturnTypeExtension.php
+++ b/src/Type/RepositoryQueryDynamicReturnTypeExtension.php
@@ -13,6 +13,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
 use SaschaEgerer\PhpstanTypo3\Helpers\Typo3ClassNamingUtilityTrait;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+use TYPO3\CMS\Extbase\Persistence\RepositoryInterface;
 
 class RepositoryQueryDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -21,7 +22,7 @@ class RepositoryQueryDynamicReturnTypeExtension implements DynamicMethodReturnTy
 
 	public function getClass(): string
 	{
-		return \TYPO3\CMS\Extbase\Persistence\RepositoryInterface::class;
+		return RepositoryInterface::class;
 	}
 
 	public function isMethodSupported(

--- a/src/Type/RequestDynamicReturnTypeExtension.php
+++ b/src/Type/RequestDynamicReturnTypeExtension.php
@@ -3,6 +3,7 @@
 namespace SaschaEgerer\PhpstanTypo3\Type;
 
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Reflection\MethodReflection;
@@ -16,10 +17,9 @@ class RequestDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtens
 {
 
 	/** @var array<string, string> */
-	private $requestGetAttributeMapping;
+	private array $requestGetAttributeMapping;
 
-	/** @var TypeStringResolver */
-	private $typeStringResolver;
+	private TypeStringResolver $typeStringResolver;
 
 	/**
 	 * @param array<string, string> $requestGetAttributeMapping
@@ -51,7 +51,7 @@ class RequestDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtens
 		$defaultArgument = $methodCall->getArgs()[1] ?? null;
 
 		if ($argument === null
-			|| !($argument->value instanceof \PhpParser\Node\Scalar\String_)
+			|| !($argument->value instanceof String_)
 			|| !isset($this->requestGetAttributeMapping[$argument->value->value])
 		) {
 			$type = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();

--- a/src/Type/SiteDynamicReturnTypeExtension.php
+++ b/src/Type/SiteDynamicReturnTypeExtension.php
@@ -3,21 +3,22 @@
 namespace SaschaEgerer\PhpstanTypo3\Type;
 
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Type;
+use TYPO3\CMS\Core\Site\Entity\Site;
 
 class SiteDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
 
 	/** @var array<string, string> */
-	private $siteGetAttributeMapping;
+	private array $siteGetAttributeMapping;
 
-	/** @var TypeStringResolver */
-	private $typeStringResolver;
+	private TypeStringResolver $typeStringResolver;
 
 	/**
 	 * @param array<string, string> $siteGetAttributeMapping
@@ -30,7 +31,7 @@ class SiteDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 
 	public function getClass(): string
 	{
-		return \TYPO3\CMS\Core\Site\Entity\Site::class;
+		return Site::class;
 	}
 
 	public function getTypeFromMethodCall(
@@ -41,7 +42,7 @@ class SiteDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 	{
 		$argument = $methodCall->getArgs()[0] ?? null;
 
-		if ($argument === null || !($argument->value instanceof \PhpParser\Node\Scalar\String_)) {
+		if ($argument === null || !($argument->value instanceof String_)) {
 			return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 		}
 

--- a/src/Type/UserAspectGetDynamicReturnTypeExtension.php
+++ b/src/Type/UserAspectGetDynamicReturnTypeExtension.php
@@ -13,6 +13,7 @@ use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
 use TYPO3\CMS\Core\Context\UserAspect;
 
 class UserAspectGetDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
@@ -32,7 +33,7 @@ class UserAspectGetDynamicReturnTypeExtension implements DynamicMethodReturnType
 		MethodReflection $methodReflection,
 		MethodCall $methodCall,
 		Scope $scope
-	): ?\PHPStan\Type\Type
+	): ?Type
 	{
 		$firstArgument = $methodCall->args[0];
 

--- a/src/Type/ValidatorResolverDynamicReturnTypeExtension.php
+++ b/src/Type/ValidatorResolverDynamicReturnTypeExtension.php
@@ -2,6 +2,7 @@
 
 namespace SaschaEgerer\PhpstanTypo3\Type;
 
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
@@ -42,7 +43,7 @@ class ValidatorResolverDynamicReturnTypeExtension implements DynamicMethodReturn
 
 		$argumentValue = $argument->value;
 
-		if (!($argumentValue instanceof \PhpParser\Node\Expr\ClassConstFetch)) {
+		if (!($argumentValue instanceof ClassConstFetch)) {
 			return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 		}
 		/** @var Name $class */


### PR DESCRIPTION
As we are on PHP 7.4 already, let´s go for native Type Declarations and drop the docblocks