### PR TITLE
Fix return type of QueryInterface::execute()

### DIFF
--- a/tests/Unit/Type/data/custom-query-type.php
+++ b/tests/Unit/Type/data/custom-query-type.php
@@ -28,15 +28,27 @@ use function PHPStan\Testing\assertType;
 class MyModelRepository extends Repository
 {
 
-	public function findBySomething(): void
+	public function findBySomething(bool $booleanParameter = false): void
 	{
 		/** @var QueryInterface<SomeOtherModel> $query */
 		$query = $this->persistenceManager->createQueryForType(SomeOtherModel::class);
 
 		$result = $query->execute();
 		assertType(
-			'TYPO3\CMS\Extbase\Persistence\QueryInterface<CustomQueryType\My\Test\Extension\Domain\Model\SomeOtherModel>',
-			$query
+			'TYPO3\CMS\Extbase\Persistence\QueryResultInterface<int, CustomQueryType\My\Test\Extension\Domain\Model\SomeOtherModel>',
+			$result
+		);
+
+		$result = $query->execute(false);
+		assertType(
+			'TYPO3\CMS\Extbase\Persistence\QueryResultInterface<int, CustomQueryType\My\Test\Extension\Domain\Model\SomeOtherModel>',
+			$result
+		);
+
+		$result = $query->execute($booleanParameter);
+		assertType(
+			'list<array<string, mixed>>|TYPO3\CMS\Extbase\Persistence\QueryResultInterface<int, CustomQueryType\My\Test\Extension\Domain\Model\SomeOtherModel>',
+			$result
 		);
 
 		$rawResult = $query->execute(true);


### PR DESCRIPTION
The execute method has a boolean argument that
defines if a raw result should be returned.
This means that no object mapping is done but
an array containing the result values is returned.

It is now also supported to not just pass constant boolean values but a variable containing a boolean to the execute function. In this case it's not clear if a raw result or objects should be returned
so we do now return a union type containing both.