### PR TITLE
Added 2 new request attribute mappings for TYPO3 v13

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -143,6 +143,8 @@ parameters:
             frontend.controller: TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController
             frontend.typoscript: TYPO3\CMS\Core\TypoScript\FrontendTypoScript
             extbase: TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters
+            frontend.page.information: TYPO3\CMS\Frontend\Page\PageInformation
+            frontend.cache.instruction: TYPO3\CMS\Frontend\Cache\CacheInstruction
         siteGetAttributeMapping:
             base: string
             baseVariants: list


### PR DESCRIPTION
* Added `frontend.page.information` - see https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendPageInformation.html#frontend-page-information

* Added `frontend.cache.instruction` - see https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendCacheInstruction.html#frontend-cache-instruction