### PR TITLE
[TASK] Use `list` whereever possible

### DIFF
--- a/stubs/ObjectStorage.stub
+++ b/stubs/ObjectStorage.stub
@@ -45,12 +45,12 @@ class ObjectStorage implements \Iterator, \ArrayAccess
     public function key();
 
     /**
-     * @return array<TEntity>
+     * @return list<TEntity>
      */
     public function toArray();
 
     /**
-     * @return array<TEntity>
+     * @return list<TEntity>
      */
     public function getArray();
 

--- a/stubs/QueryResultInterface.stub
+++ b/stubs/QueryResultInterface.stub
@@ -19,7 +19,7 @@ interface QueryResultInterface extends \Countable, \Iterator, \ArrayAccess
     public function getFirst();
 
     /**
-     * @return ModelType[]
+     * @return list<ModelType>
      */
     public function toArray();
 }


### PR DESCRIPTION
The types in the stubs should be as narrow as possible: When an array with continuous integer keys starting with 0 is returned, this is a `list`, and it should be annotated as such.