### PR TITLE
[BUGFIX] Avoid warnings about `ObjectStorage` with PHPStan 1.11.9

### DIFF
--- a/stubs/ObjectStorage.stub
+++ b/stubs/ObjectStorage.stub
@@ -42,6 +42,7 @@ class ObjectStorage implements \Iterator, \ArrayAccess
      * @phpstan-ignore-next-line See https://forge.typo3.org/issues/98146
      * @return string|null
      */
+    // @phpstan-ignore-next-line See https://forge.typo3.org/issues/98146
     public function key();
 
     /**


### PR DESCRIPTION
It looks like PHPStan 1.11.9 considers the offending line to be different in version 1.11.9.

To be compatible with both PHPStan <= 1.11.9 and 1.11.9, we now need two `@phpstan-ignore-next-line` entries.

Fixes #167