### PR TITLE
[TASK] Port some type annotation improvements from the Core

### DIFF
--- a/stubs/ObjectStorage.stub
+++ b/stubs/ObjectStorage.stub
@@ -15,24 +15,24 @@ class ObjectStorage implements \Iterator, \ArrayAccess
     protected $storage;
 
     /**
-     * @param TEntity $value
+     * @param TEntity|string|null $value
      * @param mixed $information
      */
     public function offsetSet($value, $information);
 
     /**
-     * @param TEntity|int $value
+     * @param TEntity|int|string $value
      * @return bool
      */
     public function offsetExists($value);
 
     /**
-     * @param TEntity|int $value
+     * @param TEntity|int|string $value
      */
     public function offsetUnset($value);
 
     /**
-     * @param TEntity|int $value
+     * @param TEntity|int|string $value
      * @return ($value is int ? TEntity|null : mixed)
      */
     public function offsetGet($value);
@@ -40,7 +40,7 @@ class ObjectStorage implements \Iterator, \ArrayAccess
     /**
      * This is different from the SplObjectStorage as the key in this implementation is the object hash (string).
      * @phpstan-ignore-next-line See https://forge.typo3.org/issues/98146
-     * @return string|null
+     * @return string
      */
     // @phpstan-ignore-next-line See https://forge.typo3.org/issues/98146
     public function key();

--- a/stubs/QueryInterface.stub
+++ b/stubs/QueryInterface.stub
@@ -6,6 +6,11 @@ namespace TYPO3\CMS\Extbase\Persistence;
  */
 interface QueryInterface
 {
+    // We have to define the constants here to be able to use them in other stubs.
+    // See https://phpstan.org/user-guide/stub-files
+    public const ORDER_ASCENDING = 'ASC';
+    public const ORDER_DESCENDING = 'DESC';
+    
     /**
      * @param bool $returnRawQueryResult
      * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface<ModelType>|list<array<string, mixed>>

--- a/stubs/QueryInterface.stub
+++ b/stubs/QueryInterface.stub
@@ -8,7 +8,7 @@ interface QueryInterface
 {
     /**
      * @param bool $returnRawQueryResult
-     * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface<ModelType>|array<string, mixed>
+     * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface<ModelType>|list<array<string, mixed>>
      */
     public function execute($returnRawQueryResult = false);
 

--- a/stubs/QueryResult.stub
+++ b/stubs/QueryResult.stub
@@ -10,7 +10,7 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 class QueryResult implements QueryResultInterface
 {
     /**
-     * @return null|ModelType
+     * @return ModelType|null
      */
     public function getFirst();
 }

--- a/stubs/QueryResultInterface.stub
+++ b/stubs/QueryResultInterface.stub
@@ -14,7 +14,7 @@ interface QueryResultInterface extends \Countable, \Iterator, \ArrayAccess
     public function getQuery();
 
     /**
-     * @return null|ModelType
+     * @return ModelType|null
      */
     public function getFirst();
 

--- a/stubs/Repository.stub
+++ b/stubs/Repository.stub
@@ -47,7 +47,7 @@ class Repository
     public function findByIdentifier($identifier);
 
     /**
-     * @phpstan-param array<string,string> $defaultOrderings
+     * @phpstan-param array<non-empty-string, non-empty-string> $defaultOrderings
      * @phpstan-return void
      */
     public function setDefaultOrderings($defaultOrderings);

--- a/stubs/Repository.stub
+++ b/stubs/Repository.stub
@@ -47,7 +47,7 @@ class Repository
     public function findByIdentifier($identifier);
 
     /**
-     * @phpstan-param array<non-empty-string, non-empty-string> $defaultOrderings
+     * @phpstan-param array<non-empty-string, QueryInterface::ORDER_*> $defaultOrderings
      * @phpstan-return void
      */
     public function setDefaultOrderings($defaultOrderings);


### PR DESCRIPTION
The Core recently has received some improvements on the type annotations/declerations. Port those over to our stubs.

Also rearrage some union type to have `null` always last.