### PR TITLE
[TASK] Add new frontend.page.information request attribute

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -141,6 +141,7 @@ parameters:
             routing: TYPO3\CMS\Core\Routing\SiteRouteResult|TYPO3\CMS\Core\Routing\PageArguments
             currentContentObject: TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
             frontend.controller: TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController
+            frontend.page.information: TYPO3\CMS\Frontend\Page\PageInformation
             frontend.typoscript: TYPO3\CMS\Core\TypoScript\FrontendTypoScript
             extbase: TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters
         siteGetAttributeMapping:


### PR DESCRIPTION
This got introduced with TYPO3 v13 LTS, see:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Feature-102715-NewFrontendpageinformationRequestAttribute.html

Resolves: #175