### PR TITLE
Fix invalid interface implementation by dynamic return type

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -9,6 +9,10 @@ services:
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
     -
+        class: SaschaEgerer\PhpstanTypo3\Type\ObjectStorageDynamicReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+    -
         class: SaschaEgerer\PhpstanTypo3\Type\ContextDynamicReturnTypeExtension
         arguments:
             contextApiGetAspectMapping: %typo3.contextApiGetAspectMapping%

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,24 +19,9 @@ parameters:
          - '*tests/*/data/*'
     ignoreErrors:
         -
-            message: '#^Class TYPO3\\CMS\\Core\\Context\\[a-zA-Z]* not found\.#'
-            path: src/Type/ContextDynamicReturnTypeExtension.php
-        -
             message: "#^Calling PHPStan\\\\Reflection\\\\InitializerExprTypeResolver\\:\\:getClassConstFetchType\\(\\) is not covered by backward compatibility promise\\. The method might change in a minor PHPStan version\\.$#"
             count: 1
             path: src/Rule/ValidatorResolverOptionsRule.php
-        -
-            message: "#^Method SaschaEgerer\\\\PhpstanTypo3\\\\Tests\\\\Unit\\\\Type\\\\QueryResultToArrayDynamicReturnTypeExtension\\\\FrontendUserGroupCustomFindAllWithoutModelTypeRepository\\:\\:findAll\\(\\) return type with generic interface TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface does not specify its types\\: ModelType$#"
-            count: 1
-            path: tests/Unit/Type/QueryResultToArrayDynamicReturnTypeExtension/data/query-result-to-array.php
-        -
-            message: "#^PHPDoc tag @var for variable \\$queryResult contains generic class TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\Generic\\\\QueryResult but does not specify its types\\: ModelType$#"
-            count: 2
-            path: tests/Unit/Type/QueryResultToArrayDynamicReturnTypeExtension/data/query-result-to-array.php
-        -
-            message: "#^Return type \\(TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface\\) of method SaschaEgerer\\\\PhpstanTypo3\\\\Tests\\\\Unit\\\\Type\\\\QueryResultToArrayDynamicReturnTypeExtension\\\\FrontendUserGroupCustomFindAllWithoutModelTypeRepository\\:\\:findAll\\(\\) should be covariant with return type \\(array\\<int, SaschaEgerer\\\\PhpstanTypo3\\\\Tests\\\\Unit\\\\Type\\\\QueryResultToArrayDynamicReturnTypeExtension\\\\FrontendUserGroup\\>\\|TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface\\<SaschaEgerer\\\\PhpstanTypo3\\\\Tests\\\\Unit\\\\Type\\\\QueryResultToArrayDynamicReturnTypeExtension\\\\FrontendUserGroup\\>\\) of method TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\Repository\\<SaschaEgerer\\\\PhpstanTypo3\\\\Tests\\\\Unit\\\\Type\\\\QueryResultToArrayDynamicReturnTypeExtension\\\\FrontendUserGroup\\>\\:\\:findAll\\(\\)$#"
-            count: 1
-            path: tests/Unit/Type/QueryResultToArrayDynamicReturnTypeExtension/data/query-result-to-array.php
         -
             message: '#^Although PHPStan\\Reflection\\Php\\PhpPropertyReflection is covered by backward compatibility promise, this instanceof assumption might break because it''s not guaranteed to always stay the same\.$#'
             identifier: phpstanApi.instanceofAssumption

--- a/src/Type/ObjectStorageDynamicReturnTypeExtension.php
+++ b/src/Type/ObjectStorageDynamicReturnTypeExtension.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace SaschaEgerer\PhpstanTypo3\Type;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+
+class ObjectStorageDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return ObjectStorage::class;
+	}
+
+	public function isMethodSupported(
+		MethodReflection $methodReflection
+	): bool
+	{
+		return $methodReflection->getName() === 'offsetGet';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): ?Type
+	{
+		$firstArgument = $methodCall->args[0] ?? null;
+
+		if (!$firstArgument instanceof Arg) {
+			return null;
+		}
+
+		$argumentType = $scope->getType($firstArgument->value);
+
+		if ((new StringType())->isSuperTypeOf($argumentType)->yes()) {
+			return null;
+		}
+		if ((new IntegerType())->isSuperTypeOf($argumentType)->yes()) {
+			return null;
+		}
+		return new MixedType();
+	}
+
+}

--- a/src/Type/ObjectStorageDynamicReturnTypeExtension.php
+++ b/src/Type/ObjectStorageDynamicReturnTypeExtension.php
@@ -43,11 +43,13 @@ class ObjectStorageDynamicReturnTypeExtension implements DynamicMethodReturnType
 		$argumentType = $scope->getType($firstArgument->value);
 
 		if ((new StringType())->isSuperTypeOf($argumentType)->yes()) {
-			return null;
+			return $methodReflection->getVariants()[0]->getReturnType();
 		}
+
 		if ((new IntegerType())->isSuperTypeOf($argumentType)->yes()) {
-			return null;
+			return $methodReflection->getVariants()[0]->getReturnType();
 		}
+
 		return new MixedType();
 	}
 

--- a/stubs/ObjectStorage.stub
+++ b/stubs/ObjectStorage.stub
@@ -2,7 +2,7 @@
 namespace TYPO3\CMS\Extbase\Persistence;
 
 /**
- * @template TEntity
+ * @template TEntity of object
  * @implements \ArrayAccess<string, TEntity>
  * @implements \Iterator<string, TEntity>
  * @phpstan-type ObjectStorageInternal array{obj: TEntity, inf: mixed}

--- a/stubs/ObjectStorage.stub
+++ b/stubs/ObjectStorage.stub
@@ -10,8 +10,8 @@ namespace TYPO3\CMS\Extbase\Persistence;
 class ObjectStorage implements \Iterator, \ArrayAccess
 {
     /**
-     * @param TEntity|int|string $value
-     * @return ($value is int ? TEntity|null : mixed)
+     * @param TEntity|string|int $value
+     * @phpstan-return TEntity|null
      */
-    public function offsetGet($value);
+    public function offsetGet(mixed $value);
 }

--- a/stubs/QueryResultInterface.stub
+++ b/stubs/QueryResultInterface.stub
@@ -2,7 +2,7 @@
 namespace TYPO3\CMS\Extbase\Persistence;
 
 /**
- * @template TKey
+ * @template TKey of int
  * @template TValue of object
  * @extends \Iterator<TKey, TValue>
  * @extends \ArrayAccess<TKey, TValue>

--- a/tests/Unit/Type/QueryResultToArrayDynamicReturnTypeExtension/data/query-result-to-array.php
+++ b/tests/Unit/Type/QueryResultToArrayDynamicReturnTypeExtension/data/query-result-to-array.php
@@ -135,6 +135,12 @@ class MyController extends ActionController
 			'list<SaschaEgerer\PhpstanTypo3\Tests\Unit\Type\QueryResultToArrayDynamicReturnTypeExtension\FrontendUserGroup>',
 			$myObjects
 		);
+
+		$key = $queryResult->key();
+		assertType(
+			'int',
+			$key
+		);
 	}
 
 }

--- a/tests/Unit/Type/data/object-storage-stub-files.php
+++ b/tests/Unit/Type/data/object-storage-stub-files.php
@@ -41,15 +41,11 @@ class MyModel extends AbstractEntity
 		assertType(self::class . '|null', $this->testStorage->offsetGet(0));
 		assertType(self::class . '|null', $this->testStorage->offsetGet('0'));
 		assertType(self::class . '|null', $this->testStorage->current());
-
-		// We ignore errors in the next line as this will produce an
-		// "Offset 0 does not exist on TYPO3\CMS\Extbase\Persistence\ObjectStorage<ObjectStorage\My\Test\Extension\Domain\Model\MyModel>
-		// due to the weird implementation of ArrayAccess in ObjectStorage::offsetGet()
-		// @phpstan-ignore-next-line
 		assertType(self::class . '|null', $this->testStorage[0]);
 
 		$myModel = new self();
 
+		assertType('mixed', $this->testStorage->offsetGet($this->testStorage->current()));
 		assertType('mixed', $this->testStorage->offsetGet($myModel));
 	}
 

--- a/tests/Unit/Type/data/object-storage-stub-files.php
+++ b/tests/Unit/Type/data/object-storage-stub-files.php
@@ -29,6 +29,7 @@ class MyModel extends AbstractEntity
 		}
 
 		assertType(self::class . '|null', $objectStorage->offsetGet(0));
+		assertType(self::class . '|null', $objectStorage->offsetGet('0'));
 		assertType(self::class . '|null', $objectStorage->current());
 
 		// We ignore errors in the next line as this will produce an

--- a/tests/Unit/Type/data/object-storage-stub-files.php
+++ b/tests/Unit/Type/data/object-storage-stub-files.php
@@ -29,6 +29,7 @@ class MyModel extends AbstractEntity
 		}
 
 		assertType(self::class . '|null', $objectStorage->offsetGet(0));
+		assertType(self::class . '|null', $objectStorage->current());
 
 		// We ignore errors in the next line as this will produce an
 		// "Offset 0 does not exist on TYPO3\CMS\Extbase\Persistence\ObjectStorage<ObjectStorage\My\Test\Extension\Domain\Model\MyModel>

--- a/tests/Unit/Type/data/object-storage-stub-files.php
+++ b/tests/Unit/Type/data/object-storage-stub-files.php
@@ -13,7 +13,12 @@ use function PHPStan\Testing\assertType;
 class MyModel extends AbstractEntity
 {
 
-	public function foo(): void
+	/**
+	 * @var ObjectStorage<self>
+	 */
+	protected ObjectStorage $testStorage;
+
+	public function checkObjectStorageType(): void
 	{
 		$myModel = new self();
 		/** @var ObjectStorage<MyModel> $objectStorage */
@@ -21,24 +26,31 @@ class MyModel extends AbstractEntity
 		$objectStorage->attach($myModel);
 
 		assertType('TYPO3\CMS\Extbase\Persistence\ObjectStorage<' . self::class . '>', $objectStorage);
+	}
 
-		foreach ($objectStorage as $key => $value) {
-
+	public function checkIteration(): void
+	{
+		foreach ($this->testStorage as $key => $value) {
 			assertType('string', $key);
 			assertType(self::class, $value);
 		}
+	}
 
-		assertType(self::class . '|null', $objectStorage->offsetGet(0));
-		assertType(self::class . '|null', $objectStorage->offsetGet('0'));
-		assertType(self::class . '|null', $objectStorage->current());
+	public function checkArrayAccess(): void
+	{
+		assertType(self::class . '|null', $this->testStorage->offsetGet(0));
+		assertType(self::class . '|null', $this->testStorage->offsetGet('0'));
+		assertType(self::class . '|null', $this->testStorage->current());
 
 		// We ignore errors in the next line as this will produce an
 		// "Offset 0 does not exist on TYPO3\CMS\Extbase\Persistence\ObjectStorage<ObjectStorage\My\Test\Extension\Domain\Model\MyModel>
 		// due to the weird implementation of ArrayAccess in ObjectStorage::offsetGet()
 		// @phpstan-ignore-next-line
-		assertType(self::class . '|null', $objectStorage[0]);
+		assertType(self::class . '|null', $this->testStorage[0]);
 
-		assertType('mixed', $objectStorage->offsetGet($myModel));
+		$myModel = new self();
+
+		assertType('mixed', $this->testStorage->offsetGet($myModel));
 	}
 
 }


### PR DESCRIPTION
The object storage offsetGet() is not compatible with the
ArrayAccess interface but does some TYPO3 sepcific stuff.
We can't set the correct return type via a stub as phpstan
will complain that the return type is not compatible with
the interface.
To work around this we have to implement a dynamic return
type extension again.