### PR TITLE
Add TYPO3 requestGetAttributeMapping for "originalRequest"

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -119,6 +119,7 @@ parameters:
             moduleData: TYPO3\CMS\Backend\Module\ModuleData
             nonce: TYPO3\CMS\Core\Security\ContentSecurityPolicy\ConsumableNonce
             normalizedParams: TYPO3\CMS\Core\Http\NormalizedParams
+            originalRequest: Psr\Http\Message\ServerRequestInterface
             routing: TYPO3\CMS\Core\Routing\SiteRouteResult|TYPO3\CMS\Core\Routing\PageArguments
             site: TYPO3\CMS\Core\Site\Entity\Site
             target: string


### PR DESCRIPTION
This PR fixes the PHPStan error regarding the missing `originalRequest` attribute in TYPO3’s `requestGetAttributeMapping`, mentioned in #184.
It adds the following mapping to the PHPStan config as suggested by the error message:

```neon
parameters:
    typo3:
        requestGetAttributeMapping:
            originalRequest: Psr\Http\Message\ServerRequestInterface
```

This resolves the type resolution issue for originalRequest attributes in TYPO3 projects.