### PR TITLE
Remove superfluous PHPCS comments across multiple files

### DIFF
--- a/tests/Unit/Type/DateTimeAspectGetDynamicReturnTypeExtension/data/datetime-aspect-get-return-types.php
+++ b/tests/Unit/Type/DateTimeAspectGetDynamicReturnTypeExtension/data/datetime-aspect-get-return-types.php
@@ -8,7 +8,6 @@ use TYPO3\CMS\Core\Context\DateTimeAspect;
 
 use function PHPStan\Testing\assertType;
 
-// phpcs:ignore Squiz.Classes.ClassFileName.NoMatch
 class MyContext
 {
     public function getTests(DateTimeAspect $context): void

--- a/tests/Unit/Type/PropertyMapperReturnTypeExtension/data/property-converter-types.php
+++ b/tests/Unit/Type/PropertyMapperReturnTypeExtension/data/property-converter-types.php
@@ -2,10 +2,6 @@
 
 declare(strict_types=1);
 
-// phpcs:disable SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile.MoreNamespacesInFile
-// phpcs:disable Squiz.Classes.ClassFileName.NoMatch
-// phpcs:disable PSR1.Classes.ClassDeclaration.MultipleClasses
-
 namespace SaschaEgerer\PhpstanTypo3\Tests\Unit\Type\PropertyMapperReturnTypeExtension;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;

--- a/tests/Unit/Type/QueryResultToArrayDynamicReturnTypeExtension/data/query-result-to-array.php
+++ b/tests/Unit/Type/QueryResultToArrayDynamicReturnTypeExtension/data/query-result-to-array.php
@@ -2,9 +2,6 @@
 
 declare(strict_types=1);
 
-// phpcs:disable Squiz.Classes.ClassFileName.NoMatch
-// phpcs:disable PSR1.Classes.ClassDeclaration.MultipleClasses
-
 namespace SaschaEgerer\PhpstanTypo3\Tests\Unit\Type\QueryResultToArrayDynamicReturnTypeExtension;
 
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
@@ -28,9 +25,9 @@ class FrontendUserGroupCustomFindAllRepository extends Repository
     /**
      * @return QueryResultInterface<int, FrontendUserGroup>
      */
-    public function findAll(): QueryResultInterface // phpcs:ignore SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint
+    public function findAll(): QueryResultInterface
     {
-        $queryResult = null; // phpcs:ignore SlevomatCodingStandard.Variables.UselessVariable.UselessVariable
+        $queryResult = null;
         /** @var QueryResult<FrontendUserGroup> $queryResult */
         return $queryResult;
     }
@@ -42,9 +39,9 @@ class FrontendUserGroupCustomFindAllRepository extends Repository
  */
 class FrontendUserGroupCustomFindAllWithoutModelTypeRepository extends Repository
 {
-    public function findAll(): QueryResultInterface // phpcs:ignore SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint
+    public function findAll(): QueryResultInterface
     {
-        $queryResult = null; // phpcs:ignore SlevomatCodingStandard.Variables.UselessVariable.UselessVariable
+        $queryResult = null;
         /** @var QueryResult<FrontendUserGroup> $queryResult */
         return $queryResult;
     }
@@ -56,9 +53,9 @@ class FrontendUserGroupCustomFindAllWithoutModelTypeRepository extends Repositor
  */
 class FrontendUserGroupCustomFindAllWithoutAnnotationRepository extends Repository
 {
-    public function findAll() // phpcs:ignore SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint
+    public function findAll()
     {
-        $queryResult = null; // phpcs:ignore SlevomatCodingStandard.Variables.UselessVariable.UselessVariable
+        $queryResult = null;
         /** @var QueryResult $queryResult */
         return $queryResult;
     }

--- a/tests/Unit/Type/UserAspectGetDynamicReturnTypeExtension/data/user-aspect-get-return-types.php
+++ b/tests/Unit/Type/UserAspectGetDynamicReturnTypeExtension/data/user-aspect-get-return-types.php
@@ -8,7 +8,6 @@ use TYPO3\CMS\Core\Context\UserAspect;
 
 use function PHPStan\Testing\assertType;
 
-// phpcs:ignore Squiz.Classes.ClassFileName.NoMatch
 class MyContext
 {
     public function getTests(UserAspect $context): void

--- a/tests/Unit/Type/data/context-get-aspect-return-types.php
+++ b/tests/Unit/Type/data/context-get-aspect-return-types.php
@@ -14,7 +14,6 @@ use TYPO3\CMS\Core\Context\WorkspaceAspect;
 
 use function PHPStan\Testing\assertType;
 
-// phpcs:ignore Squiz.Classes.ClassFileName.NoMatch
 class MyContext
 {
     public function getAspectTests(Context $context): void

--- a/tests/Unit/Type/data/custom-query-type.php
+++ b/tests/Unit/Type/data/custom-query-type.php
@@ -2,10 +2,6 @@
 
 declare(strict_types=1);
 
-// phpcs:disable SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile.MoreNamespacesInFile
-// phpcs:disable Squiz.Classes.ClassFileName.NoMatch
-// phpcs:disable PSR1.Classes.ClassDeclaration.MultipleClasses
-
 namespace CustomQueryType\My\Test\Extension\Domain\Model;
 
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;

--- a/tests/Unit/Type/data/object-storage-stub-files.php
+++ b/tests/Unit/Type/data/object-storage-stub-files.php
@@ -2,10 +2,6 @@
 
 declare(strict_types=1);
 
-// phpcs:disable SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile.MoreNamespacesInFile
-// phpcs:disable Squiz.Classes.ClassFileName.NoMatch
-// phpcs:disable PSR1.Classes.ClassDeclaration.MultipleClasses
-
 namespace ObjectStorage\My\Test\Extension\Domain\Model;
 
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;

--- a/tests/Unit/Type/data/query-factory-stub-files.php
+++ b/tests/Unit/Type/data/query-factory-stub-files.php
@@ -8,7 +8,6 @@ use TYPO3\CMS\Extbase\Persistence\Generic\QueryFactory;
 
 use function PHPStan\Testing\assertType;
 
-// phpcs:ignore Squiz.Classes.ClassFileName.NoMatch
 class Model extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
 {
     public function foo(): void

--- a/tests/Unit/Type/data/repository-stub-files.php
+++ b/tests/Unit/Type/data/repository-stub-files.php
@@ -2,10 +2,6 @@
 
 declare(strict_types=1);
 
-// phpcs:disable SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile.MoreNamespacesInFile
-// phpcs:disable Squiz.Classes.ClassFileName.NoMatch
-// phpcs:disable PSR1.Classes.ClassDeclaration.MultipleClasses
-
 namespace RepositoryStubFiles\My\Test\Extension\Domain\Model;
 
 class MyModel extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
@@ -120,9 +116,9 @@ class FindAllWithoutReturnTestRepository extends \TYPO3\CMS\Extbase\Persistence\
         );
     }
 
-    public function findAll() // phpcs:ignore SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint
+    public function findAll()
     {
-        $foo = null; // phpcs:ignore SlevomatCodingStandard.Variables.UselessVariable.UselessVariable
+        $foo = null;
         /**
          * @var list<\RepositoryStubFiles\My\Test\Extension\Domain\Model\MyModel>|\TYPO3\CMS\Extbase\Persistence\QueryResultInterface<int, \RepositoryStubFiles\My\Test\Extension\Domain\Model\MyModel> $foo
          */

--- a/tests/Unit/Type/data/request-get-attribute-return-types.php
+++ b/tests/Unit/Type/data/request-get-attribute-return-types.php
@@ -12,7 +12,6 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 
 use function PHPStan\Testing\assertType;
 
-// phpcs:ignore Squiz.Classes.ClassFileName.NoMatch
 class MyRequest
 {
     public function getAttributeTests(ServerRequestInterface $request): void

--- a/tests/Unit/Type/data/site-get-attribute-return-types.php
+++ b/tests/Unit/Type/data/site-get-attribute-return-types.php
@@ -8,7 +8,6 @@ use TYPO3\CMS\Core\Site\Entity\Site;
 
 use function PHPStan\Testing\assertType;
 
-// phpcs:ignore Squiz.Classes.ClassFileName.NoMatch
 class MySite
 {
     public function getAttributeTests(Site $site): void


### PR DESCRIPTION
Eliminate unnecessary phpcs:disable and phpcs:ignore comments