### PR TITLE
Fix forceIntegerInRange() type inference with PHPStan >= 2.1.52

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -59,6 +59,10 @@ services:
         tags:
             - phpstan.typeSpecifier.staticMethodTypeSpecifyingExtension
     -
+        class: SaschaEgerer\PhpstanTypo3\Type\MathUtilityForceIntegerInRangeDynamicReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
+    -
         class: SaschaEgerer\PhpstanTypo3\Type\GeneralUtilityGetIndpEnvDynamicReturnTypeExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension

--- a/src/Type/MathUtilityForceIntegerInRangeDynamicReturnTypeExtension.php
+++ b/src/Type/MathUtilityForceIntegerInRangeDynamicReturnTypeExtension.php
@@ -35,20 +35,34 @@ class MathUtilityForceIntegerInRangeDynamicReturnTypeExtension implements Dynami
             return null;
         }
 
-        $min = $this->resolveIntegerValue($scope->getType($args[1]->value));
-        $max = isset($args[2]) ? $this->resolveIntegerValue($scope->getType($args[2]->value)) : self::DEFAULT_MAX;
+        [$minLowerBound] = $this->resolveBounds($scope->getType($args[1]->value));
+        [$maxLowerBound, $maxUpperBound] = isset($args[2])
+            ? $this->resolveBounds($scope->getType($args[2]->value))
+            : [self::DEFAULT_MAX, self::DEFAULT_MAX];
 
-        if ($min !== null && $max !== null && $min > $max) {
-            // forceIntegerInRange() clamps to $min first and to $max afterwards, so $max wins
-            return new ConstantIntegerType($max);
-        }
+        // forceIntegerInRange() clamps to $min first and to $max afterwards, so with
+        // $max < $min the result drops below $min and $max becomes the effective minimum
+        $lowerBound = $minLowerBound !== null && $maxLowerBound !== null
+            ? min($minLowerBound, $maxLowerBound)
+            : null;
 
-        return IntegerRangeType::fromInterval($min, $max);
+        return IntegerRangeType::fromInterval($lowerBound, $maxUpperBound);
     }
 
-    private function resolveIntegerValue(Type $type): ?int
+    /**
+     * @return array{?int, ?int}
+     */
+    private function resolveBounds(Type $type): array
     {
-        return $type instanceof ConstantIntegerType ? $type->getValue() : null;
+        if ($type instanceof ConstantIntegerType) {
+            return [$type->getValue(), $type->getValue()];
+        }
+
+        if ($type instanceof IntegerRangeType) {
+            return [$type->getMin(), $type->getMax()];
+        }
+
+        return [null, null];
     }
 
 }

--- a/src/Type/MathUtilityForceIntegerInRangeDynamicReturnTypeExtension.php
+++ b/src/Type/MathUtilityForceIntegerInRangeDynamicReturnTypeExtension.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SaschaEgerer\PhpstanTypo3\Type;
+
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\Type;
+use TYPO3\CMS\Core\Utility\MathUtility;
+
+class MathUtilityForceIntegerInRangeDynamicReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
+{
+    private const DEFAULT_MAX = 2000000000;
+
+    public function getClass(): string
+    {
+        return MathUtility::class;
+    }
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'forceIntegerInRange';
+    }
+
+    public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
+    {
+        $args = $methodCall->getArgs();
+
+        if (!isset($args[1])) {
+            return null;
+        }
+
+        $min = $this->resolveIntegerValue($scope->getType($args[1]->value));
+        $max = isset($args[2]) ? $this->resolveIntegerValue($scope->getType($args[2]->value)) : self::DEFAULT_MAX;
+
+        if ($min !== null && $max !== null && $min > $max) {
+            // forceIntegerInRange() clamps to $min first and to $max afterwards, so $max wins
+            return new ConstantIntegerType($max);
+        }
+
+        return IntegerRangeType::fromInterval($min, $max);
+    }
+
+    private function resolveIntegerValue(Type $type): ?int
+    {
+        return $type instanceof ConstantIntegerType ? $type->getValue() : null;
+    }
+
+}

--- a/src/Type/MathUtilityTypeSpecifyingExtension.php
+++ b/src/Type/MathUtilityTypeSpecifyingExtension.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace SaschaEgerer\PhpstanTypo3\Type;
 
-use PhpParser\Node\Arg;
-use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
 use PhpParser\Node\Expr\BinaryOp\GreaterOrEqual;
 use PhpParser\Node\Expr\BinaryOp\SmallerOrEqual;
@@ -13,7 +11,6 @@ use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
-use PhpParser\Node\Scalar\LNumber;
 use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\SpecifiedTypes;
 use PHPStan\Analyser\TypeSpecifier;
@@ -25,10 +22,6 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 final class MathUtilityTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
-    private const METHOD_FORCE_INTEGER_IN_RANGE = 'forceIntegerInRange';
-
-    private const METHOD_CONVERT_TO_POSITIVE_INTEGER = 'convertToPositiveInteger';
-
     private const METHOD_CAN_BE_INTERPRETED_AS_INTEGER = 'canBeInterpretedAsInteger';
 
     private const METHOD_CAN_BE_INTERPRETED_AS_FLOAT = 'canBeInterpretedAsFloat';
@@ -52,8 +45,6 @@ final class MathUtilityTypeSpecifyingExtension implements StaticMethodTypeSpecif
         return in_array(
             $staticMethodReflection->getName(),
             [
-                self::METHOD_FORCE_INTEGER_IN_RANGE,
-                self::METHOD_CONVERT_TO_POSITIVE_INTEGER,
                 self::METHOD_CAN_BE_INTERPRETED_AS_INTEGER,
                 self::METHOD_CAN_BE_INTERPRETED_AS_FLOAT,
                 self::METHOD_IS_INTEGER_IN_RANGE,
@@ -64,16 +55,8 @@ final class MathUtilityTypeSpecifyingExtension implements StaticMethodTypeSpecif
 
     public function specifyTypes(MethodReflection $staticMethodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
-        if ($staticMethodReflection->getName() === self::METHOD_FORCE_INTEGER_IN_RANGE) {
-            return $this->specifyTypesForForceIntegerInRange($node, $scope);
-        }
-
         if ($staticMethodReflection->getName() === self::METHOD_IS_INTEGER_IN_RANGE) {
             return $this->specifyTypesForIsIntegerInRange($node, $scope);
-        }
-
-        if ($staticMethodReflection->getName() === self::METHOD_CONVERT_TO_POSITIVE_INTEGER) {
-            return $this->specifyTypesForConvertToPositiveInteger($node, $scope);
         }
 
         if ($staticMethodReflection->getName() === self::METHOD_CAN_BE_INTERPRETED_AS_INTEGER) {
@@ -81,39 +64,6 @@ final class MathUtilityTypeSpecifyingExtension implements StaticMethodTypeSpecif
         }
 
         return $this->specifyTypesForCanBeInterpretedAsFloat($node, $scope);
-    }
-
-    private function specifyTypesForForceIntegerInRange(StaticCall $node, Scope $scope): SpecifiedTypes
-    {
-        $parentNode = $node->getAttribute('parent');
-
-        if (!$parentNode instanceof Assign) {
-            return new SpecifiedTypes();
-        }
-
-        $min = isset($node->getArgs()[1]) ? $node->getArgs()[1]->value : new LNumber(0);
-        $max = isset($node->getArgs()[2]) ? $node->getArgs()[2]->value : new LNumber(2000000000);
-
-        return $this->typeSpecifier->specifyTypesInCondition(
-            $scope,
-            new BooleanAnd(
-                new FuncCall(
-                    new Name('is_int'),
-                    [new Arg($parentNode->var)]
-                ),
-                new BooleanAnd(
-                    new GreaterOrEqual(
-                        $parentNode->var,
-                        $min
-                    ),
-                    new SmallerOrEqual(
-                        $parentNode->var,
-                        $max
-                    )
-                )
-            ),
-            TypeSpecifierContext::createTruthy()
-        );
     }
 
     private function specifyTypesForIsIntegerInRange(StaticCall $node, Scope $scope): SpecifiedTypes
@@ -156,36 +106,6 @@ final class MathUtilityTypeSpecifyingExtension implements StaticMethodTypeSpecif
                     new SmallerOrEqual(
                         $firstArgument->value,
                         $max
-                    )
-                )
-            ),
-            TypeSpecifierContext::createTruthy()
-        );
-    }
-
-    private function specifyTypesForConvertToPositiveInteger(StaticCall $node, Scope $scope): SpecifiedTypes
-    {
-        $parentNode = $node->getAttribute('parent');
-
-        if (!$parentNode instanceof Assign) {
-            return new SpecifiedTypes();
-        }
-
-        return $this->typeSpecifier->specifyTypesInCondition(
-            $scope,
-            new BooleanAnd(
-                new FuncCall(
-                    new Name('is_int'),
-                    [new Arg($parentNode)]
-                ),
-                new BooleanAnd(
-                    new GreaterOrEqual(
-                        $parentNode->var,
-                        new LNumber(0)
-                    ),
-                    new SmallerOrEqual(
-                        $parentNode->var,
-                        new LNumber(PHP_INT_MAX)
                     )
                 )
             ),

--- a/tests/Unit/Type/MathUtilityTypeSpecifyingExtension/data/MathUtilityType.php
+++ b/tests/Unit/Type/MathUtilityTypeSpecifyingExtension/data/MathUtilityType.php
@@ -34,6 +34,20 @@ final class MathUtilityType
         assertType('int<4, 2000000000>', $forceIntegerInRange);
     }
 
+    public function forceIntegerInRangeWithNonConstantBoundaries(int $theInt, int $min, int $max): void
+    {
+        $forceIntegerInRange = MathUtility::forceIntegerInRange($theInt, $min, 100);
+        assertType('int<min, 100>', $forceIntegerInRange);
+
+        $forceIntegerInRange = MathUtility::forceIntegerInRange($theInt, 0, $max);
+        assertType('int<0, max>', $forceIntegerInRange);
+    }
+
+    public function forceIntegerInRangeUsedAsExpression(int $theInt): void
+    {
+        assertType('int<10, 20>', MathUtility::forceIntegerInRange($theInt, 10, 20));
+    }
+
     public function isIntegerInRange($a, string $b, float $c, int $d, int $e, int $f, int $min, int $max): void
     {
         if (MathUtility::isIntegerInRange($a, 0, 200)) {

--- a/tests/Unit/Type/MathUtilityTypeSpecifyingExtension/data/MathUtilityType.php
+++ b/tests/Unit/Type/MathUtilityTypeSpecifyingExtension/data/MathUtilityType.php
@@ -39,8 +39,24 @@ final class MathUtilityType
         $forceIntegerInRange = MathUtility::forceIntegerInRange($theInt, $min, 100);
         assertType('int<min, 100>', $forceIntegerInRange);
 
+        // $max may be smaller than the constant minimum at runtime, so no lower bound is guaranteed
+        $forceIntegerInRange = MathUtility::forceIntegerInRange($theInt, 0, $max);
+        assertType('int', $forceIntegerInRange);
+    }
+
+    /**
+     * @param positive-int $max
+     */
+    public function forceIntegerInRangeWithPositiveIntMaxBoundary(int $theInt, int $max): void
+    {
         $forceIntegerInRange = MathUtility::forceIntegerInRange($theInt, 0, $max);
         assertType('int<0, max>', $forceIntegerInRange);
+    }
+
+    public function forceIntegerInRangeWithMaxLowerThanMin(int $theInt): void
+    {
+        $forceIntegerInRange = MathUtility::forceIntegerInRange($theInt, 30, 20);
+        assertType('20', $forceIntegerInRange);
     }
 
     public function forceIntegerInRangeUsedAsExpression(int $theInt): void


### PR DESCRIPTION
PHPStan 2.1.52 changed the TypeSpecifier conditional-expression-holder merge logic so that the synthetic "is_int() && >= && <=" condition used by MathUtilityTypeSpecifyingExtension no longer narrows the assigned variable to int<min, max>, breaking the type inference tests.

Replace the TypeSpecifier hack with a DynamicStaticMethodReturnTypeExtension that computes the return type of MathUtility::forceIntegerInRange() directly from the arguments via IntegerRangeType::fromInterval(). This is robust against TypeSpecifier internals, also works when the call is used as an expression without an assignment, and infers partial ranges like int<0, max> for non-constant boundaries.

Also drop the convertToPositiveInteger() handling as the method no longer exists in TYPO3 14.