### PR TITLE
Streamline early terminating method calls

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -159,32 +159,11 @@ parameters:
         - TYPO3_mainDir
     earlyTerminatingMethodCalls:
         TYPO3\CMS\Extbase\Mvc\Controller\ActionController:
-            - redirectToUri
-            - redirect
-            - forward
-            - forwardToReferringRequest
             - throwStatus
-        TYPO3\CMS\Extbase\Mvc\Controller\AbstractController:
-            - redirectToUri
-            - redirect
-            - forward
-            - throwStatus
-        TYPO3\CMS\Core\Utility\HttpUtility:
-            - redirect
-            - setResponseCodeAndExit
         TYPO3\CMS\Form\Domain\Finishers\RedirectFinisher:
             - redirectToUri
-        TYPO3\CMS\Extbase\Mvc\Controller\CommandController:
-            - forward
-            - quit
-        TYPO3\CMS\Extensionmanager\Utility\FileHandlingUtility:
-            - sendZipFileToBrowserAndDelete
-        TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController:
-            - pageUnavailableAndExit
-            - pageNotFoundAndExit
-            - pageErrorHandler
-        TYPO3\CMS\Recordlist\RecordList\DatabaseRecordList:
-            - pageErrorHandler
+        TYPO3\CMS\Core\Console\CommandApplication:
+            - run
 parametersSchema:
     typo3: structure([
         containerXmlPath: schema(string(), nullable())


### PR DESCRIPTION
Drop methods that no longer exist or no longer terminate and add CommandApplication::run() which calls exit().